### PR TITLE
improve perf coordxtracts

### DIFF
--- a/src/utilities/coordxtr.jl
+++ b/src/utilities/coordxtr.jl
@@ -22,8 +22,12 @@ function coordxtr(Edof,Coord,Dof,nen)
         nodnum = zeros(Int, nen)
         for j = 1:nen
             ele_dof =  Edof[i, (j-1)*nend + 2 : j*nend + 1]
-            for k = 1:nnodes
-                if Dof[k, :] - ele_dof == [0 0]
+             for k = 1:nnodes
+                s = zero(eltype(Edof))
+                for l in 1:size(Dof, 2)
+                    s += abs(Dof[k, l] - ele_dof[l])
+                end
+                if s == 0
                     nodnum[j] = k
                     break
                 end
@@ -64,7 +68,11 @@ function topologyxtr(Edof,Coord,Dof,nen)
         for j = 1:nen
             ele_dof =  Edof[i, (j-1)*nend + 2 : j*nend + 1]
             for k = 1:nnodes
-                if Dof[k, :] - ele_dof == [0 0]
+                s = zero(eltype(Edof))
+                for l in 1:size(Dof, 2)
+                    s += abs(Dof[k, l] - ele_dof[l])
+                end
+                if s == 0
                     nodnum[j] = k
                     break
                 end


### PR DESCRIPTION
De var sjukt långsamma

```jl
p1 = [0.0, 0.0]
p2 = [1.0, 1.]
nelx = 60
nely = 80
ndofs = 2
Edof, Ex, Ey, B1, B2, B3, B4, coord, dof = gen_quad_mesh(p1, p2, nelx, nely, ndofs)
```

## Innan PR
```
julia> @time topologyxtr(Edof,coord,dof, 3)
  7.429985 seconds (234.23 M allocations: 10.887 GB, 17.36% gc time)
```

## Efter PR
```
julia> @time topologyxtr(Edof,coord,dof, 3)
  0.146927 seconds (92.43 k allocations: 3.425 MB, 3.12% gc time)
```