### PR TITLE
transpose ALL the things

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,6 +1,16 @@
 Welcome to JuAFEM.jl's documentation!
 =====================================
 
+
+## Differences between CALFEM and JuAFEM.
+
+
+* CALFEM made some unfortunate choices in how they set up their matrices for dofs and coordinates. Both Julia and MATLAB use [column major order](https://en.wikipedia.org/wiki/Row-major_order) which means that memory is stored column by column. We therefore also want to store for example the dofs for an element in a column.
+The concrete effect of this is that the following matrices are transposed in JuAFEM: `Edof`, `Ex`, `Ey`, `Ez`, `Dof`, `Coord`.
+The dofs for element `k` is therefore computed by `Edof[2:end, k]` instead of like in MATLAB `Edof(k, 2:end)`.
+
+* Some functions in CALFEM can compute a quantity for many elements at a time. In JuAFEM, you need to loop over the elements and call the function with each separate element.
+
 .. _api:
 
 #####

--- a/examples/patch_test.ipynb
+++ b/examples/patch_test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 425,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 354,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 350,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -46,7 +46,7 @@
        "Winston.FramedPlot(...)"
       ]
      },
-     "execution_count": 350,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 358,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -85,7 +85,7 @@
     "    dof = bc_dofs[i]\n",
     "    node = div(dof+1, 2)\n",
     "    bc[i, 1] = dof\n",
-    "    bc[i, 2] = cx * coords[node, 1] + cy * coords[node, 2]\n",
+    "    bc[i, 2] = cx * coords[1, node] + cy * coords[2, node,]\n",
     "end"
    ]
   },
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 361,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -106,14 +106,14 @@
    "source": [
     "a = start_assemble()\n",
     "D = hooke(2, 250e9, 0.3)\n",
-    "for e in 1:size(Edof, 1)\n",
-    "    ex = Ex[Edof[e,1], :]'\n",
-    "    ey = Ey[Edof[e,1], :]'\n",
+    "for e in 1:size(Edof, 2)\n",
+    "    ex = Ex[:, Edof[1,e]]\n",
+    "    ey = Ey[:, Edof[1,e]]\n",
     "    Ke, _ = plani4e(ex, ey, [2, 1, 2], D)\n",
-    "    assemble(Edof[e, :], a, Ke)\n",
+    "    assemble(Edof[:, e], a, Ke)\n",
     "end\n",
     "K = end_assemble(a);\n",
-    "a, _ = solve_eq_sys(K, zeros(32), bc);"
+    "a, _ = solveq(K, zeros(32), bc);"
    ]
   },
   {
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 422,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -137,19 +137,19 @@
        "Winston.FramedPlot(...)"
       ]
      },
-     "execution_count": 422,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "Ed = extract_eldisp(Edof, a);\n",
-    "JuAFEM.eldisp2(Ex, Ey, Ed)"
+    "Ed = extract(Edof, a);\n",
+    "eldisp2(Ex, Ey, Ed)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 423,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -157,23 +157,30 @@
     {
      "data": {
       "text/plain": [
-       "1x8 Array{Float64,2}:\n",
-       " 0.05  0.05  0.0833333  0.0833333  0.1  0.1  0.0666667  0.0666667"
+       "8-element Array{Float64,1}:\n",
+       " 0.05     \n",
+       " 0.05     \n",
+       " 0.0833333\n",
+       " 0.0833333\n",
+       " 0.1      \n",
+       " 0.1      \n",
+       " 0.0666667\n",
+       " 0.0666667"
       ]
      },
-     "execution_count": 423,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Displacements center element\n",
-    "Ed[5,:]"
+    "Ed[:,5]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 421,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -188,24 +195,26 @@
        " 0.1      "
       ]
      },
-     "execution_count": 421,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Center nodes: 6 7 10 11\n",
-    "coords[[6,7,10,11], :] * [cx; cy]"
+    "coords[:, [6,7,10,11]]' * [cx; cy]"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 0.4.0-dev",
+   "display_name": "Julia 0.4.0-rc1",
    "language": "julia",
    "name": "julia-0.4"
   },
   "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
    "name": "julia",
    "version": "0.4.0"
   }

--- a/examples/springs.ipynb
+++ b/examples/springs.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -38,14 +38,14 @@
        "1.0"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "k = 1.0;                        # Spring stiffness [N/m]\n",
-    "F = 1.0;                        # Load magnitude [N]"
+    "k = 1.0;   # Spring stiffness [N/m]\n",
+    "F = 1.0;   # Load magnitude [N]"
    ]
   },
   {
@@ -57,13 +57,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "ep1 = k;                        # Stiffness for spring 1 etc.\n",
+    "ep1 = k;    # Stiffness for spring 1 etc.\n",
     "ep2 = 2*k;   \n",
     "ep3 = k;"
    ]
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -87,22 +87,22 @@
     {
      "data": {
       "text/plain": [
-       "3x3 Array{Int32,2}:\n",
-       " 1  1  2\n",
-       " 2  2  3\n",
-       " 3  3  4"
+       "3x3 Array{Int64,2}:\n",
+       " 1  2  3\n",
+       " 1  2  3\n",
+       " 2  3  4"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "# Note the transpose in the end\n",
     "Edof = [1  1 2                 # Element 1: node 1->2\n",
     "        2  2 3                 # Element 2: node 2->3\n",
-    "        3  3 4];               # Element 3: node 3->4\n",
-    " "
+    "        3  3 4]';              # Element 3: node 3->4"
    ]
   },
   {
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -133,18 +133,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "K = zeros(4,4);                  # Allocate space \n",
+    "K = zeros(4,4);      # Allocate space \n",
     "f = zeros(4,1);    \n",
     "\n",
-    "f[3] = F;                       # Apply load in dof 2\n",
+    "f[3] = F;             # Apply load in dof 2\n",
     " \n",
-    "Ke1 = spring1e(ep1);            # Element stiffness matrices\n",
+    "Ke1 = spring1e(ep1);  # Element stiffness matrices\n",
     "Ke2 = spring1e(ep2);\n",
     "Ke3 = spring1e(ep3);"
    ]
@@ -175,9 +175,9 @@
     }
    ],
    "source": [
-    "K = assemble(Edof[1,:], K, Ke1)\n",
-    "K = assemble(Edof[2,:], K, Ke2) \n",
-    "K = assemble(Edof[3,:], K, Ke3) \n",
+    "K = assemble(Edof[:,1], K, Ke1)\n",
+    "K = assemble(Edof[:,2], K, Ke2) \n",
+    "K = assemble(Edof[:,3], K, Ke3) \n",
     "print(K)"
    ]
   },
@@ -190,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -201,8 +201,8 @@
      "text": [
       "Displacement vector: a = [0.0,0.39999999999999997,0.6,0.0]\n",
       "Boundary forces:  = [-0.39999999999999997\n",
-      " -5.551115123125783e-17\n",
       " 0.0\n",
+      " -1.1102230246251565e-16\n",
       " -0.6]\n"
      ]
     }
@@ -210,8 +210,8 @@
    "source": [
     "(a, fb) = solveq(K, f, bc)      # a - vector of computed displacements\n",
     "                                # fb - vector of computed boundary forces (zero for unconstrained dofs)\n",
-    "println (\"Displacement vector: a = $a\")\n",
-    "println (\"Boundary forces:  = $fb\")"
+    "println(\"Displacement vector: a = $a\")\n",
+    "println(\"Boundary forces:  = $fb\")"
    ]
   },
   {
@@ -223,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -240,23 +240,25 @@
     "el_disp = extract(Edof, a);     # Matrix contining the displacement vectors for each element \n",
     "\n",
     "\n",
-    "es1 = spring1s(ep1, el_disp[1,:])        # Compute spring force in each element\n",
-    "es2 = spring1s(ep2, el_disp[2,:])\n",
-    "es3 = spring1s(ep3, el_disp[3,:])\n",
+    "es1 = spring1s(ep1, el_disp[:,1])        # Compute spring force in each element\n",
+    "es2 = spring1s(ep2, el_disp[:,2])\n",
+    "es3 = spring1s(ep3, el_disp[:,3])\n",
     "\n",
-    "print (\"Sectional forces are: N1 = $es1, N2 = $es2, N3 = $es3\")"
+    "print(\"Sectional forces are: N1 = $es1, N2 = $es2, N3 = $es3\")"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 0.3.10",
+   "display_name": "Julia 0.4.0-rc1",
    "language": "julia",
-   "name": "julia-0.3"
+   "name": "julia-0.4"
   },
   "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.3.10"
+   "version": "0.4.0"
   }
  },
  "nbformat": 4,

--- a/src/elements/CALFEM_API.jl
+++ b/src/elements/CALFEM_API.jl
@@ -6,8 +6,8 @@ for (f_calfem, f_juafem) in ((:plani4e, :solid_square_1e),
                              (:plani8s, :solid_square_2s),
                              (:plants,  :solid_tri_1s))
     @eval begin
-        function $f_calfem(ex::VecOrMat, ey::VecOrMat, ep::Array,
-                           D::Matrix, eq::VecOrMat=zeros(2))
+        function $f_calfem(ex::Vector, ey::Vector, ep::Vector,
+                           D::Matrix, eq::Vector=zeros(2))
             # TODO, fix plane stress
             ptype = convert(Int, ep[1])
             t = ep[2]
@@ -22,7 +22,7 @@ for (f_calfem, f_juafem) in ((:plani4f, :solid_square_1f),
                              (:plani8f, :solid_square_2f),
                              (:plantf,  :solid_tri_1f))
     @eval begin
-        function $f_calfem(ex::VecOrMat, ey::VecOrMat, ep::Array,
+        function $f_calfem(ex::Vector, ey::Vector, ep::Vector,
                            es::VecOrMat)
             # TODO, fix plane stress
             ptype = convert(Int, ep[1])
@@ -38,8 +38,8 @@ end
 for (f_calfem, f_juafem) in ((:soli8e, :solid_cube_1e),
                              (:soli8s, :solid_cube_1s))
     @eval begin
-        function $f_calfem(ex::VecOrMat, ey::VecOrMat, ez::VecOrMat, ep::Array,
-                           D::Matrix, eq::VecOrMat=zeros(3))
+        function $f_calfem(ex::Vector, ey::Vector, ez::Vector, ep::Vector,
+                           D::Matrix, eq::Vector=zeros(3))
             int_order = convert(Int, ep[1])
             x = [ex ey ez]
             $f_juafem(x, D, eq, int_order)
@@ -49,7 +49,7 @@ end
 
 for (f_calfem, f_juafem) in ((:soli8f, :solid_cube_1f),)
     @eval begin
-        function $f_calfem(ex::VecOrMat, ey::VecOrMat, ez::VecOrMat, ep::Array,
+        function $f_calfem(ex::Vector, ey::Vector, ez::Vector, ep::Vector,
                            es::VecOrMat)
             int_order = convert(Int, ep[1])
             x = [ex ey ez]
@@ -66,8 +66,8 @@ for (f_calfem, f_juafem) in ((:flw2i4e, :heat_square_1e),
                              (:flw2i8s, :heat_square_2s),
                              (:flw2ts,  :heat_tri_1s))
     @eval begin
-        function $f_calfem(ex::VecOrMat, ey::VecOrMat, ep::Array,
-                           D::Matrix, eq::VecOrMat=zeros(1))
+        function $f_calfem(ex::Vector, ey::Vector, ep::Vector,
+                           D::Matrix, eq::Vector=zeros(1))
             # TODO, fix plane stress
             t = ep[1]
             int_order = convert(Int, ep[2])
@@ -81,8 +81,8 @@ end
 for (f_calfem, f_juafem) in ((:flw3i8e, :heat_cube_1e),
                              (:flw3i8s, :heat_cube_1s))
     @eval begin
-        function $f_calfem(ex::VecOrMat, ey::VecOrMat, ez::VecOrMat, ep::Array,
-                           D::Matrix, eq::VecOrMat=zeros(1))
+        function $f_calfem(ex::Vector, ey::Vector, ez::Vector, ep::Vector,
+                           D::Matrix, eq::Vector=zeros(1))
             # TODO, fix plane stress
             int_order = convert(Int, ep[1])
             x = [ex ey ez]

--- a/src/elements/bar.jl
+++ b/src/elements/bar.jl
@@ -3,7 +3,7 @@
 
 Computes the element stiffness matrix `Ke` for a 2D bar element.
 """
-function bar2e(ex::VecOrMat, ey::VecOrMat, elem_prop::VecOrMat)
+function bar2e(ex::Vector, ey::Vector, elem_prop::Vector)
 
     # Local element stiffness
     E = elem_prop[1];  A = elem_prop[2]
@@ -32,7 +32,7 @@ end
 
 Computes the sectional force (normal force) `N` for a 2D bar element.
 """
-function bar2s(ex::VecOrMat, ey::VecOrMat, elem_prop::VecOrMat, el_disp::VecOrMat)
+function bar2s(ex::Vector, ey::Vector, elem_prop::Vector, el_disp::Vector)
 
     E = elem_prop[1];  A = elem_prop[2]
 
@@ -70,7 +70,7 @@ const __bar2g_c2 = Float64[0  0  0  0;
 Computes the element stiffness matrix `Ke` for a
 geometrically nonlinear 2D bar element.
 """
-function bar2g(ex::VecOrMat, ey::VecOrMat, elem_prop::VecOrMat, N::Number)
+function bar2g(ex::Vector, ey::Vector, elem_prop::Vector, N::Number)
 
     E = elem_prop[1];  A = elem_prop[2]
 

--- a/src/elements/elements.jl
+++ b/src/elements/elements.jl
@@ -125,9 +125,9 @@ function gen_s_body(ele)
         qr = get_gaussrule($(ele.shape), int_order)
 
         n_gps = length(qr.points)
-        FLUXES = zeros(n_gps, fluxlen)
-        CONJS = zeros(n_gps, fluxlen)
-        points = zeros(n_gps, ndim)
+        FLUXES = zeros(fluxlen, n_gps)
+        CONJS = zeros(fluxlen, n_gps)
+        points = zeros(ndim, n_gps)
 
         for (i, ξ) in enumerate(qr.points)
             evaluate_N!($(ele.shape_funcs), N, ξ)
@@ -141,9 +141,9 @@ function gen_s_body(ele)
             $(ele.flux_kernel())
             ##############################
 
-            FLUXES[i, :] = FLUX_KERNEL
-            CONJS[i, :] = CONJ_KERNEL
-            points[i, :] = x' * N
+            FLUXES[:, i] = FLUX_KERNEL
+            CONJS[:, i] = CONJ_KERNEL
+            points[:, i] = x' * N
         end
         return FLUXES, CONJS, points
     end
@@ -199,7 +199,7 @@ function gen_f_body(ele)
         # elements reference shape
         qr = get_gaussrule($(ele.shape), int_order)
 
-        if size(σs, 1) != length(qr.points)
+        if size(σs, 2) != length(qr.points)
             throw(ArgumentError("must use same integration rule to compute stresses and internal forces"))
         end
 
@@ -210,7 +210,7 @@ function gen_f_body(ele)
             Jinv = inv_spec(J)
             @into! dNdx = Jinv * dNdξ
             dV = det_spec(J) * w
-            σ = vec(σs[i, :])
+            σ = vec(σs[:, i])
 
             ##############################
             # Call the elements flux kernel

--- a/src/elements/spring.jl
+++ b/src/elements/spring.jl
@@ -4,7 +4,7 @@
 Computes the element stiffness matrix `Ke` for a
 spring element with stiffness `k`.
 """
-function spring1e(k)
+function spring1e(k::Number)
     Ke = [k -k;
           -k k]
 end
@@ -15,7 +15,7 @@ end
 Computes the force `fe` for a spring element with stiffness
 `k` and displacements `u`.
 """
-function spring1s(k, u::VecOrMat)
+function spring1s(k::Number, u::Vector)
     if length(u) != 2
         throw(ArgumentError("displacements for computing the spring force must" *
                             "be a vector of length 2"))

--- a/src/utilities/assemble.jl
+++ b/src/utilities/assemble.jl
@@ -2,7 +2,7 @@
 Assembles the the element stiffness matrix `Ke`
 to the global stiffness matrix `K`.
 """
-function assemble(edof::Array, K::AbstractMatrix, Ke::Matrix)
+function assemble(edof::Vector, K::AbstractMatrix, Ke::Matrix)
     (nr, nc) = size(Ke)
     if nr != nc
         throw(DimensionMismatch("Stiffness matrix is not square (#rows=$nr #cols=$nc)"))
@@ -10,9 +10,7 @@ function assemble(edof::Array, K::AbstractMatrix, Ke::Matrix)
         len_edof = length(edof)
         throw(DimensionMismatch("Mismatch between sizes in edof and Ke (edof($len_edof) Ke($nr,$nc)"))
     end
-    _Ke = convert(Matrix{Float64}, Ke)
-    _edof = convert(Array{Int}, edof)
-    dofs = vec(_edof[2:end])
+    dofs = edof[2:end]
     K[dofs, dofs] += Ke
     return K
 end

--- a/src/utilities/assembler.jl
+++ b/src/utilities/assembler.jl
@@ -23,7 +23,7 @@ end
 
 Assembles the element matrix `Ke` into `a`.
 """
-function assemble(edof, a::Assembler, Ke::Matrix)
+function assemble(edof::Vector, a::Assembler, Ke::Matrix)
     for ele in size(edof, 1)
         append!(a.V, Ke[:])
         for dof1 in edof[2:end], dof2 in edof[2:end]

--- a/src/utilities/coordxtr.jl
+++ b/src/utilities/coordxtr.jl
@@ -9,23 +9,23 @@ function coordxtr(Edof,Coord,Dof,nen)
 
     # TODO: Input checks
 
-    nel, dofsperele = size(Edof)
+    dofsperele, nel = size(Edof)
     dofsperele -= 1 # Compensate for ele index
-    nnodes, ndim = size(Coord)
+    ndim, nnodes = size(Coord)
     nend = div(dofsperele, nen)
 
-    Ex = zeros(nel, nen)
+    Ex = zeros(nen, nel)
     Ey = zeros(Ex)
     Ez = zeros(Ex);
 
     for i = 1:nel
         nodnum = zeros(Int, nen)
         for j = 1:nen
-            ele_dof =  Edof[i, (j-1)*nend + 2 : j*nend + 1]
+            ele_dof =  Edof[(j-1)*nend + 2 : j*nend + 1, i]
              for k = 1:nnodes
                 s = zero(eltype(Edof))
-                for l in 1:size(Dof, 2)
-                    s += abs(Dof[k, l] - ele_dof[l])
+                for l in 1:size(Dof, 1)
+                    s += abs(Dof[l, k] - ele_dof[l])
                 end
                 if s == 0
                     nodnum[j] = k
@@ -34,12 +34,12 @@ function coordxtr(Edof,Coord,Dof,nen)
             end
         end
 
-        Ex[i, :] = Coord[nodnum, 1]
+        Ex[:, i] = Coord[1, nodnum]
         if ndim > 1
-            Ey[i, :] = Coord[nodnum, 2]
+            Ey[:, i] = Coord[2, nodnum]
         end
         if ndim > 2
-            Ez[i, :] = Coord[nodnum, 3]
+            Ez[:, i] = Coord[3, nodnum]
         end
     end
     return Ex, Ey, Ez
@@ -56,21 +56,21 @@ function topologyxtr(Edof,Coord,Dof,nen)
 
     # TODO: Input checks
 
-    nel, dofsperele = size(Edof)
+    dofsperele, nel = size(Edof)
     dofsperele -= 1 # Compensate for ele index
-    nnodes, ndim = size(Coord)
+    ndim, nnodes = size(Coord)
     nend = div(dofsperele, nen)
 
-    topology = zeros(Int, nel, nen)
+    topology = zeros(Int, nen, nel)
 
     for i = 1:nel
         nodnum = zeros(Int, nen)
         for j = 1:nen
-            ele_dof =  Edof[i, (j-1)*nend + 2 : j*nend + 1]
-            for k = 1:nnodes
+            ele_dof =  Edof[(j-1)*nend + 2 : j*nend + 1, i]
+             for k = 1:nnodes
                 s = zero(eltype(Edof))
-                for l in 1:size(Dof, 2)
-                    s += abs(Dof[k, l] - ele_dof[l])
+                for l in 1:size(Dof, 1)
+                    s += abs(Dof[l, k] - ele_dof[l])
                 end
                 if s == 0
                     nodnum[j] = k
@@ -79,7 +79,7 @@ function topologyxtr(Edof,Coord,Dof,nen)
             end
         end
 
-        topology[i, :] = nodnum
+        topology[:, i] = nodnum
 
     end
     return topology

--- a/src/utilities/extract_eldisp.jl
+++ b/src/utilities/extract_eldisp.jl
@@ -7,13 +7,13 @@ number of dofs.
 """
 function extract(edof::VecOrMat, a::VecOrMat)
 
-    (nel, temp) = size(edof);
-    neldofs = temp - 1
+    neldofs, nel = size(edof);
+    neldofs -=  1
 
-    eldisp = zeros(nel, neldofs)
+    eldisp = zeros(neldofs, nel)
 
     for el = 1:nel
-        eldisp[el, :] = a[edof[el, 2:end]]
+        eldisp[:, el] = a[edof[2:end, el]]
     end
     return eldisp
 end

--- a/src/utilities/gen_quad_mesh.jl
+++ b/src/utilities/gen_quad_mesh.jl
@@ -74,6 +74,7 @@ function gen_quad_mesh(p1::Array, p2::Array, nelx::Int, nely::Int, ndofs::Int)
   B3 = dofs[(nelx+1)*(nely+1):-1:(nelx+1)*(nely)+1,:]
   B4 = dofs[(nelx+1)*(nely:-1:0)+1,:]
 
-  return Edof, Ex, Ey, B1, B2, B3, B4, coords
+  return Edof', Ex', Ey', B1', B2', B3', B4', coords', dofs'
+
 end
 

--- a/src/utilities/plotting.jl
+++ b/src/utilities/plotting.jl
@@ -20,23 +20,24 @@ function eldraw2(ex::VecOrMat, ey::VecOrMat,
 
     plot_string = LTYPES[ltype] * LCOLORS[lcolor] * LMARKS[lmark]
 
-    nx = size(ex, 2)
-    ny = size(ey, 2)
-    center = [sum(ex, 2)/nx sum(ey, 2)/ny]
+    nx = size(ex, 1)
+    ny = size(ey, 1)
+
+    center = [sum(ex, 1)/nx; sum(ey, 1)/ny]
 
     # TODO can't we make this a bit nicer /JB
-    npoints = size(ex , 1)
+    npoints = size(ex , 2)
 
     if npoints == 2
       xs = ex
       ys = ey
     else
-      xs = [ex ex[:, 1]]'
-      ys = [ey ey[:, 1]]'
+      xs = [ex; ex[1, :]]
+      ys = [ey; ey[1, :]]
     end
     p = Winston.plot(xs, ys, plot_string)
     for el in elnum
-         Winston.text(center[el,1], center[el,2], string(el))
+         Winston.text(center[1, el], center[2, el], string(el))
     end
 
     return p
@@ -63,13 +64,13 @@ function eldisp2(ex::VecOrMat, ey::VecOrMat, ed::VecOrMat,
     plot_string = LTYPES[ltype] * LCOLORS[lcolor] * LMARKS[lmark]
 
     # TODO can't we make this a bit nicer /JB
-    npoints = size(ex,1)
+    npoints = size(ex, 2)
     if npoints == 2
-      xs = ex + sfac * ed[:, 1:2:end]
-      ys = ey + sfac * ed[:, 2:2:end]
+      xs = ex + sfac * ed[1:2:end, :]
+      ys = ey + sfac * ed[2:2:end, :]
     else
-      xs = [ex + sfac * ed[:, 1:2:end] ex[:,1] + sfac * ed[:,1]]'
-      ys = [ey + sfac * ed[:, 2:2:end] ey[:,1] + sfac * ed[:,2]]'
+      xs = [ex + sfac * ed[1:2:end, :]; ex[1, :] + sfac * ed[1, :]]
+      ys = [ey + sfac * ed[2:2:end, :]; ey[1, :] + sfac * ed[2, :]]
     end
     p = Winston.plot(xs, ys, plot_string)
 

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -133,8 +133,8 @@ context("plani4s/f") do
 
 
     # correct for calfems order of gauss points
-    @fact norm(σ - σ_calfem[[4,2,3,1], :]) / norm(σ_calfem) --> roughly(0.0, atol=1e-14)
-    @fact norm(ε - ε_calfem[[4,2,3,1], :]) / norm(ε_calfem) --> roughly(0.0, atol=1e-14)
+    @fact norm(σ - σ_calfem[[4,2,3,1], :]') / norm(σ_calfem) --> roughly(0.0, atol=1e-14)
+    @fact norm(ε - ε_calfem[[4,2,3,1], :]') / norm(ε_calfem) --> roughly(0.0, atol=1e-14)
     @fact norm(intf - intf_calfem) / norm(intf_calfem) --> roughly(0.0, atol=1e-14)
 
 
@@ -175,8 +175,8 @@ context("plants/f") do
       7.010769230769229]
 
 
-    @fact norm(σ - σ_calfem) / norm(σ_calfem) --> roughly(0.0, atol=1e-14)
-    @fact norm(ε - ε_calfem) / norm(ε_calfem) --> roughly(0.0, atol=1e-14)
+    @fact norm(σ - σ_calfem') / norm(σ_calfem') --> roughly(0.0, atol=1e-14)
+    @fact norm(ε - ε_calfem') / norm(ε_calfem') --> roughly(0.0, atol=1e-14)
     @fact norm(intf - intf_calfem) / norm(intf_calfem) --> roughly(0.0, atol=1e-14)
 
 end
@@ -275,8 +275,8 @@ context("soli8s/f") do
   -1.958109485444647;
   -1.639108853140777]
 
-    @fact norm(σ - σ_calfem[[1,5,4,8,2,6,3,7], [1,2,3,6,5,4]]) / norm(σ_calfem) --> roughly(0.0, atol=1e-5)
-    @fact norm(ε - ε_calfem[[1,5,4,8,2,6,3,7], [1,2,3,6,5,4]]) / norm(ε_calfem) --> roughly(0.0, atol=1e-5)
+    @fact norm(σ - σ_calfem[[1,5,4,8,2,6,3,7], [1,2,3,6,5,4]]') / norm(σ_calfem) --> roughly(0.0, atol=1e-5)
+    @fact norm(ε - ε_calfem[[1,5,4,8,2,6,3,7], [1,2,3,6,5,4]]') / norm(ε_calfem) --> roughly(0.0, atol=1e-5)
     @fact norm(intf - intf_calfem) / norm(intf_calfem) --> roughly(0.0, atol=1e-14)
 end
 
@@ -347,8 +347,8 @@ context("plani8s/f") do
           -1.556915325616566]
 
 
-      @fact norm(σ - σ_calfem[[1,3, 2, 4], :]) / norm(σ_calfem) --> roughly(0.0, atol =1e-13)
-      @fact norm(ε - ε_calfem[[1,3, 2, 4], :]) / norm(ε_calfem) --> roughly(0.0, atol=1e-13)
+      @fact norm(σ - σ_calfem[[1,3, 2, 4], :]') / norm(σ_calfem) --> roughly(0.0, atol =1e-13)
+      @fact norm(ε - ε_calfem[[1,3, 2, 4], :]') / norm(ε_calfem) --> roughly(0.0, atol=1e-13)
       @fact norm(intf - intf_calfem) / norm(intf_calfem) --> roughly(0.0, atol=1e-14)
 end
 
@@ -381,8 +381,8 @@ context("flw2i4s") do
      -1.723760430703402   5.732050807568878;
      -1.261880215351701   3.422649730810373]
 
-      @fact norm(es - es_calfem[[4,2, 3, 1], :]) / norm(es_calfem) --> roughly(0.0, atol =1e-13)
-      @fact norm(et - et_calfem[[4,2, 3, 1], :]) / norm(et_calfem) --> roughly(0.0, atol=1e-13)
+      @fact norm(es - es_calfem[[4,2, 3, 1], :]') / norm(es_calfem) --> roughly(0.0, atol =1e-13)
+      @fact norm(et - et_calfem[[4,2, 3, 1], :]') / norm(et_calfem) --> roughly(0.0, atol=1e-13)
 end
 
 context("flw2i8e") do
@@ -421,8 +421,8 @@ context("flw2i8s") do
   -2.187219748188395   6.921119965694889;
    5.855440108225263   4.135429337120202]
 
-    @fact norm(es - es_calfem[[1 ,3, 2, 4], :]) / norm(es_calfem) --> roughly(0.0, atol =1e-13)
-    @fact norm(et - et_calfem[[1 ,3, 2, 4], :]) / norm(et_calfem) --> roughly(0.0, atol=1e-13)
+    @fact norm(es - es_calfem[[1 ,3, 2, 4], :]') / norm(es_calfem) --> roughly(0.0, atol =1e-13)
+    @fact norm(et - et_calfem[[1 ,3, 2, 4], :]') / norm(et_calfem) --> roughly(0.0, atol=1e-13)
 end
 
 
@@ -448,8 +448,8 @@ context("flw2ts") do
     es_calfem = [-2.8 -6.4;]
     et_calfem = [0.8 1.0;]
 
-    @fact norm(es - es_calfem) / norm(es_calfem) --> roughly(0.0, atol =1e-13)
-    @fact norm(et - et_calfem) / norm(et_calfem) --> roughly(0.0, atol=1e-13)
+    @fact norm(es - es_calfem') / norm(es_calfem) --> roughly(0.0, atol =1e-13)
+    @fact norm(et - et_calfem') / norm(et_calfem) --> roughly(0.0, atol=1e-13)
 end
 
 
@@ -498,8 +498,8 @@ context("flw3i8s") do
     -0.781769647374687   5.905082103747760   2.078287062219387;
     -0.666357396405506   4.994845707601153   3.209293306780562]
 
-    @fact norm(es - es_calfem[[1,5,4,8,2,6,3,7], :]) / norm(es_calfem) --> roughly(0.0, atol =1e-13)
-    @fact norm(et - et_calfem[[1,5,4,8,2,6,3,7], :]) / norm(et_calfem) --> roughly(0.0, atol=1e-13)
+    @fact norm(es - es_calfem[[1,5,4,8,2,6,3,7], :]') / norm(es_calfem) --> roughly(0.0, atol =1e-13)
+    @fact norm(et - et_calfem[[1,5,4,8,2,6,3,7], :]') / norm(et_calfem) --> roughly(0.0, atol=1e-13)
 end
 
 

--- a/test/test_elements.jl
+++ b/test/test_elements.jl
@@ -50,7 +50,7 @@ context("plani4e") do
                  2 1
                  2 2
                  1 2
-                 0 2]
+                 0 2]'
 
         Dof = [1 2
                3 4
@@ -60,19 +60,19 @@ context("plani4e") do
                11 12
                13 14
                15 16
-               17 18]
+               17 18]'
 
         Edof = [1 1 2 3 4 5 6 7 8;
                 2 3 4 9 10 11 12 5 6;
                 3 5 6 11 12 13 14 15 16;
-                4 7 8 5 6 15 16 17 18]
+                4 7 8 5 6 15 16 17 18]'
 
         function get_coord(dof)
           node = div(dof+1, 2)
           if dof % 2 == 0
-              return Coord[node, 2]
+              return Coord[2, node]
           else
-              return Coord[node, 1]
+              return Coord[1, node]
           end
         end
 
@@ -83,18 +83,18 @@ context("plani4e") do
         for i in 1:size(bc, 1)
           dof = bc_dofs[i]
           node = div(dof+1, 2)
-          coord = Coord[node, :]
+          coord = Coord[:, node]
           bc[i, 1] = dof
           bc[i, 2] = ux * coord[1] + uy * coord[2]
         end
 
           a = start_assemble()
           D = hooke(2, 250e9, 0.3)
-          for e in 1:size(Edof, 1)
-            ex = [get_coord(i) for i in Edof[e, 2:2:end]]
-            ey = [get_coord(i) for i in Edof[e, 3:2:end]]
+          for e in 1:size(Edof, 2)
+            ex = [get_coord(i) for i in Edof[2:2:end, e]]
+            ey = [get_coord(i) for i in Edof[3:2:end, e]]
             Ke, _ = plani4e(ex, ey, [2, 1, 2], D)
-            assemble(Edof[e, :], a, Ke)
+            assemble(Edof[:, e], a, Ke)
           end
           K = end_assemble(a)
           a, _ = solveq(K, zeros(18), bc)
@@ -506,10 +506,10 @@ end
 
 context("bar") do
     # From example 3.2 in the book Strukturmekanik
-    ex = [0.  1.6]; ey = [0. -1.2]
-    elem_prop = [200.e9 1.0e-3]
+    ex = [0.,  1.6]; ey = [0., -1.2]
+    elem_prop = [200.e9, 1.0e-3]
     Ke = bar2e(ex, ey, elem_prop)
-    ed = [0. 0. -0.3979 -1.1523]*1e-3
+    ed = [0., 0., -0.3979 ,-1.1523]*1e-3
     N = bar2s(ex, ey, elem_prop, ed)
     Ke_ref = [ 64  -48. -64  48
               -48   36   48 -36

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -5,12 +5,12 @@ facts("Utility testing") do
 context("assemble") do
     K = zeros(3,3)
     Ke = [1 2 3; 4 5 6; 7 8 9]
-    edof = [1  3 2 1]
+    edof = [1, 3, 2, 1]
     @fact assemble(edof, K, Ke) --> [9.0 8.0 7.0; 6.0 5.0 4.0; 3.0 2.0 1.0]
     # Test non square Ke
     @fact_throws DimensionMismatch assemble(edof, K, [1 2 3; 4 5 6])
     # Test wrong length of edof
-    @fact_throws DimensionMismatch assemble([1 2 3], K, Ke)
+    @fact_throws DimensionMismatch assemble([1, 2, 3], K, Ke)
 end
 
 context("solveq") do
@@ -37,9 +37,9 @@ end
 
 context("extract") do
     a = [0.0 5.0 7.0 9.0 11.0]
-    edof = [1  2 4
-            2  3 5]
-    @fact extract(edof, a) --> [5.0 9.0; 7.0 11.0]
+    edof = [1 2 4
+            2 3 5]'
+    @fact extract(edof, a) --> [5.0 9.0; 7.0 11.0]'
 end
 
 context("linalg") do
@@ -69,26 +69,26 @@ context("gen_quad_mesh") do
      3 7 8 9 10 15 16 13 14
      4 9 10 11 12 17 18 15 16
      5 13 14 15 16 21 22 19 20
-     6 15 16 17 18 23 24 21 22]
+     6 15 16 17 18 23 24 21 22]'
     Ex_r =
     [0.0 0.5 0.5 0.0
      0.5 1.0 1.0 0.5
      0.0 0.5 0.5 0.0
      0.5 1.0 1.0 0.5
      0.0 0.5 0.5 0.0
-     0.5 1.0 1.0 0.5]
+     0.5 1.0 1.0 0.5]'
     Ey_r =
     [0.0 0.0 0.3333333333333333 0.3333333333333333
      0.0 0.0 0.3333333333333333 0.3333333333333333
      0.3333333333333333 0.3333333333333333 0.6666666666666666 0.6666666666666666
      0.3333333333333333 0.3333333333333333 0.6666666666666666 0.6666666666666666
      0.6666666666666666 0.6666666666666666 1.0 1.0
-     0.6666666666666666 0.6666666666666666 1.0 1.0]
+     0.6666666666666666 0.6666666666666666 1.0 1.0]'
 
-    B1_r = [1 2; 3 4; 5 6]
-    B2_r = [5 6; 11 12; 17 18; 23 24]
-    B3_r = [23 24; 21 22; 19 20]
-    B4_r = [19 20; 13 14; 7 8; 1 2]
+    B1_r = [1 2; 3 4; 5 6]'
+    B2_r = [5 6; 11 12; 17 18; 23 24]'
+    B3_r = [23 24; 21 22; 19 20]'
+    B4_r = [19 20; 13 14; 7 8; 1 2]'
     @fact Edof --> Edof_r
     @fact norm(Ex - Ex_r) / norm(Ex_r) --> roughly(0.0, atol=1e-15)
     @fact norm(Ey - Ey_r) / norm(Ey_r) --> roughly(0.0, atol=1e-15)
@@ -126,28 +126,28 @@ context("coordxtr + topologyxtr") do
     Dof = [1 2;
            3 4;
            5 6;
-           7 8]
+           7 8]'
 
     Coord = [1.0 3.0;
              2.0 4.0;
              5.0 6.0
-             7.0 8.0]
+             7.0 8.0]'
 
     Edof = [1 1 2 3 4 5 6;
-            2 1 2 3 4 7 8]
+            2 1 2 3 4 7 8]'
 
     Ex, Ey, Ez = coordxtr(Edof,Coord,Dof, 3)
 
     @fact Ex --> [1.0 2.0 5.0;
-                  1.0 2.0 7.0]
+                  1.0 2.0 7.0]'
 
     @fact Ey --> [3.0 4.0 6.0;
-                  3.0 4.0 8.0]
+                  3.0 4.0 8.0]'
 
     topo = topologyxtr(Edof,Coord,Dof, 3)
 
     @fact topo --> [1 2 3;
-                    1 2 4]
+                    1 2 4]'
 end
 
 


### PR DESCRIPTION
Efter att ha jobbat lite med en datoruppgift inser jag att det är ohållbart att köra med CALFEMs radvektorer.

La in detta i manualen och transponerade det som behövdes.:


* CALFEM made some unfortunate choices in how they set up their matrices for dofs and coordinates. Both Julia and MATLAB use [column major order](https://en.wikipedia.org/wiki/Row-major_order) which means that memory is stored column by column. We therefore also want to store for example the dofs for an element in a column.
The concrete effect of this is that the following matrices are transposed in JuAFEM: `Edof`, `Ex`, `Ey`, `Ez`, `Dof`, `Coord`.
The dofs for element `k` is therefore computed by `Edof[2:end, k]` instead of like in MATLAB `Edof(k, 2:end)`.