### PR TITLE
add getters for function space and quadrule, also fix arugment order

### DIFF
--- a/src/JuAFEM.jl
+++ b/src/JuAFEM.jl
@@ -30,7 +30,7 @@ export solve_eq_sys, solveq
 export extract, coordxtr, topologyxtr
 export statcon
 export start_assemble, assemble, assem, end_assemble, eldraw2, eldisp2, gen_quad_mesh
-export FEValues, reinit!, shape_value, shape_derivative, detJdV
+export FEValues, reinit!, shape_value, shape_derivative, detJdV, get_quadrule, get_functionspace
 export Lagrange, Serenipity
 export get_gaussrule
 

--- a/src/utilities/fe_values.jl
+++ b/src/utilities/fe_values.jl
@@ -41,6 +41,9 @@ function reinit!(fe_v::FEValues, x::Matrix)
     end
 end
 
+get_quadrule(fe_v::FEValues) = fe_v.quad_rule
+get_functionspace(fe_v::FEValues) = fe_v.function_space
+
 """
 Gets the product between the determinant of the Jacobian and the quadrature point weight for a given quadrature point.
 """
@@ -70,9 +73,6 @@ Get the derivatives of the shape functions for a given quadrature point and base
 """
 Get the derivatives of the shape functions for a given quadrature point, base_function and component
 """
-@inline shape_derivative(fe_v::FEValues, base_func::Int, q_point::Int, component::Int) = fe_v.dNdx[q_point][component, base_func]
-
-
-#divergence!(fe_v::FEValues, u::)
+@inline shape_derivative(fe_v::FEValues, q_point::Int, base_func::Int, component::Int) = fe_v.dNdx[q_point][component, base_func]
 
 


### PR DESCRIPTION
- Adds method to get the function space and quadrarture rule from a `FEValues` type.
- Makes the argument order consistent in `shape_derivative`.

