### PR TITLE
WIP: started on function interpolations

### DIFF
--- a/doc/api/fe_values.rst
+++ b/doc/api/fe_values.rst
@@ -1,0 +1,121 @@
+.. currentmodule:: JuAFEM
+
+.. _api-fe_values:
+
+FE Values
+---------
+
+To assist with creating new finite elements ``JuAFEM`` has the concept of an object called
+``FEValues``. The idea for this was taken from deal.ii_.
+
+An ``FEValues`` object facilitates with evaluating shape functions, gradient of shape functions and evaluating values on operators of finite element discretized functions.
+
+Initializing an ``FEValues`` object is done with two other objects. One ``FunctionSpace`` object and one ``QuadratureRule``.
+
+Function spaces
+^^^^^^^^^^^^^^^
+A function space is described by its name, for example ``Lagrange``, an order of the base functions and a shape which the space is defined on.
+
+The following function spaces are currently available:
+
+- ``Lagrange{1, JuaFEM.Line}``
+- ``Lagrange{2, JuaFEM.Line}``
+- ``Lagrange{1, JuaFEM.Square}``
+- ``Lagrange{1, JuaFEM.Triangle}``
+- ``Lagrange{1, JuaFEM.Triangle}``
+- ``Lagrange{2, JuaFEM.Triangle}``
+- ``Lagrange{1, JuaFEM.Cube}``
+- ``Serendipity{2, JuaFEM.Square}``
+
+Quadrature
+^^^^^^^^^^
+
+Currently only Gauss quadrature is implemented. A `QuadratureRule` is created from ``get_gaussrule(shape, order)`` where shape is an instance of one of the shapes shown in the function space list above and order is the order of the quadrature rule.
+
+
+Using FE Values
+^^^^^^^^^^^^^^^
+
+An example of creating a ``FEValues`` object is shown below.
+
+.. code-block:: julia
+    quad_rule = get_gaussrule(JuAFEM.Square(), 2)
+    func_space = func_space = Lagrange{1, JuaFEM.Square}()
+    fe_values = FEValues(func_space, quad_rule)
+
+Upon creation, ``FEValues`` caches the values of the shape functions and derivatives in the quadrature points.
+
+The points of FEValues is that for each element you call ``reinit!(fev, x)`` where ``x`` is the coordinate matrix for an element. This will update the global shape function derivatives, jacobians, weights etc.
+
+Different queries can now be performed.
+
+Shape function queries
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. function:: shape_value(fe_v, q_point::Int) -> value
+
+   .. Docstring generated from Julia source
+
+   Gets the value of the shape function for a given quadrature point
+
+.. function:: shape_value(fe_v, q_point::Int, base_func::Int) -> value
+
+   .. Docstring generated from Julia source
+
+   Gets the value of the shape function at a given quadrature point and given base function
+
+.. function:: shape_gradient(fe_v, q_point::Int) -> gradient::Matrix
+
+   .. Docstring generated from Julia source
+
+   Get the gradients of the shape functions for a given quadrature point
+
+.. function:: shape_gradient(fe_v, q_point::Int, base_func::Int) -> gradient::Vector
+
+   .. Docstring generated from Julia source
+
+   Get the gradient of the shape functions for a given quadrature point and base function
+
+.. function:: shape_gradient(fe_v, q_point::Int, base_func::Int, component::Int) -> gradient_component
+
+   .. Docstring generated from Julia source
+
+   Get the gradient of the shape functions for a given quadrature point, base function and component
+
+
+Discretized function queries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We can also compute different operatiors on a finite element discretized function:
+
+.. function:: function_scalar_value(fe_v, q_point::Int, u::Vector) -> value
+
+   .. Docstring generated from Julia source
+
+   Computes the value in a quadrature point for a scalar valued function
+
+.. function:: function_scalar_gradient!(grad::Vector, fe_v, q_point::Int, u::Vector) -> gradient
+
+   .. Docstring generated from Julia source
+
+   Computes the gradient in a quadrature point for a scalar valued function. Result is stored in ``grad``\ .
+
+.. function:: function_vector_gradient!(grad::Matrix, fe_v, q_point::Int, u::Vector) -> gradient
+
+   .. Docstring generated from Julia source
+
+   Computes the gradient (jacobian) in a quadrature point for a vector valued function. Result is stored in ``grad``\ .
+
+.. function:: function_vector_symmetric_gradient!(grad::Matrix, fe_v, q_point::Int, u::Vector) -> sym_gradient
+
+   .. Docstring generated from Julia source
+
+   Computes the symmetric gradient (jacobian) in a quadrature point for a vector valued function. Result is stored in ``grad``\ .
+
+.. function:: function_vector_divergence(fe_v, q_point::Int, u::Vector) -> divergence
+
+   .. Docstring generated from Julia source
+
+   Computes the divergence in a quadrature point for a vector valued function.
+
+.. _https://www.dealii.org/developer/doxygen/deal.II/classFEValues.html

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,5 +24,6 @@ Differences between CALFEM and JuAFEM
     api/elements
     api/materials
     api/utilities
+    api/fe_values
 
 __ https://en.wikipedia.org/wiki/Row-major_order

--- a/src/JuAFEM.jl
+++ b/src/JuAFEM.jl
@@ -30,7 +30,10 @@ export solve_eq_sys, solveq
 export extract, coordxtr, topologyxtr
 export statcon
 export start_assemble, assemble, assem, end_assemble, eldraw2, eldisp2, gen_quad_mesh
-export FEValues, reinit!, shape_value, shape_derivative, detJdV, get_quadrule, get_functionspace
+export FEValues, reinit!, shape_value, shape_gradient, detJdV, get_quadrule, get_functionspace,
+                 function_scalar_value, function_vector_value!, function_scalar_gradient!,
+                 function_vector_gradient!, function_vector_divergence, function_vector_symmetric_gradient!
+export n_dim, n_basefunctions
 export Lagrange, Serenipity
 export get_gaussrule
 

--- a/src/utilities/fe_values.jl
+++ b/src/utilities/fe_values.jl
@@ -10,9 +10,9 @@ type FEValues{T <: Real, QR <: QuadratureRule, FS <: FunctionSpace}
 end
 
 """
-Initializes an FEValues object from a function space and a quadrature rule.
+Initializes an `FEValues` object from a function space and a quadrature rule.
 """
-function FEValues{QR <: QuadratureRule, FS <: FunctionSpace}(T::Type, quad_rule::QR, func_space::FS)
+function FEValues{T, QR <: QuadratureRule, FS <: FunctionSpace}(::Type{T}, quad_rule::QR, func_space::FS)
         n_basefuncs = n_basefunctions(func_space)
         dim = n_dim(func_space)
 
@@ -31,7 +31,13 @@ function FEValues{QR <: QuadratureRule, FS <: FunctionSpace}(T::Type, quad_rule:
 
         FEValues{T, QR, FS}(J, Jinv, N, dNdx, dNdξ, zeros(T, n_qpoints), quad_rule, func_space)
 end
+function FEValues{QR <: QuadratureRule, FS <: FunctionSpace}(quad_rule::QR, func_space::FS)
+    FEValues(Float64, quad_rule, func_space)
+end
 
+"""
+Updates the `FEValues` object for the current element with coordinate matrix `x`.
+"""
 function reinit!(fe_v::FEValues, x::Matrix)
     for (i, (ξ, w)) in enumerate(zip(fe_v.quad_rule.points, fe_v.quad_rule.weights))
         @into! fe_v.J = fe_v.dNdξ[i] * x'
@@ -41,7 +47,14 @@ function reinit!(fe_v::FEValues, x::Matrix)
     end
 end
 
+"""
+Returns the quadrature rule.
+"""
 get_quadrule(fe_v::FEValues) = fe_v.quad_rule
+
+"""
+Returns the function space.
+"""
 get_functionspace(fe_v::FEValues) = fe_v.function_space
 
 """
@@ -51,32 +64,47 @@ Gets the product between the determinant of the Jacobian and the quadrature poin
 @inline detJdV(fe_v::FEValues, q_point::Int) = fe_v.detJdV[q_point]
 
 """
+    shape_value(fe_v, q_point::Int) -> value
+
 Gets the value of the shape function for a given quadrature point
 """
 @inline shape_value(fe_v::FEValues, q_point::Int) = fe_v.N[q_point]
 
 """
+    shape_value(fe_v, q_point::Int, base_func::Int) -> value
+
 Gets the value of the shape function at a given quadrature point and given base function
 """
 @inline shape_value(fe_v::FEValues, q_point::Int, base_func::Int) = fe_v.N[q_point][base_func]
 
 """
+    shape_gradient(fe_v, q_point::Int) -> gradient::Matrix
+
 Get the gradients of the shape functions for a given quadrature point
 """
 @inline shape_gradient(fe_v::FEValues, q_point::Int) = fe_v.dNdx[q_point]
 
 """
+    shape_gradient(fe_v, q_point::Int, base_func::Int) -> gradient::Vector
+
 Get the gradient of the shape functions for a given quadrature point and base function
 """
 @inline shape_gradient(fe_v::FEValues, q_point::Int, base_func::Int) = fe_v.dNdx[q_point][:, base_func]
 
 """
+    shape_gradient(fe_v, q_point::Int, base_func::Int, component::Int) -> gradient_component
+
 Get the gradient of the shape functions for a given quadrature point, base function and component
 """
 @inline shape_gradient(fe_v::FEValues, q_point::Int, base_func::Int, component::Int) = fe_v.dNdx[q_point][component, base_func]
 
 const shape_derivative = shape_gradient
 
+"""
+    function_scalar_value(fe_v, q_point::Int, u::Vector) -> value
+
+Computes the value in a quadrature point for a scalar valued function
+"""
 @inline function function_scalar_value{T}(fe_v::FEValues, q_point::Int, u::Vector{T})
     func_space = get_functionspace(fe_v)
     @assert length(u) == n_basefunctions(func_space)
@@ -85,6 +113,12 @@ const shape_derivative = shape_gradient
 end
 
 # u should be given as [x, y, z, x, y, z, ...]
+"""
+     function_vector_value!(vec::Vector, fe_v, q_point::Int, u::Vector) -> value
+
+Computes the value in a quadrature point for a vector valued function. Result is stored
+in `vec`
+"""
 @inline function function_vector_value!{T}(vec::Vector{T}, fe_v::FEValues, q_point::Int, u::Vector{T})
     func_space = get_functionspace(fe_v)
     dim = n_dim(func_space)
@@ -102,6 +136,12 @@ end
     return vec
 end
 
+"""
+    function_scalar_gradient!(grad::Vector, fe_v, q_point::Int, u::Vector) -> gradient
+
+Computes the gradient in a quadrature point for a scalar valued function. Result
+is stored in `grad`.
+"""
 @inline function function_scalar_gradient!{T}(grad::Vector{T}, fe_v::FEValues, q_point::Int, u::Vector{T})
     func_space = get_functionspace(fe_v)
     @assert length(u) == n_basefunctions(func_space)
@@ -112,6 +152,12 @@ end
 end
 
 # u should be given as [x, y, z, x, y, z, ...]
+"""
+    function_vector_gradient!(grad::Matrix, fe_v, q_point::Int, u::Vector) -> gradient
+
+Computes the gradient (jacobian) in a quadrature point for a vector valued function. Result
+is stored in `grad`.
+"""
 @inline function function_vector_gradient!{T}(grad::Matrix{T}, fe_v::FEValues, q_point::Int, u::Vector{T})
     func_space = get_functionspace(fe_v)
     n_base_funcs = n_basefunctions(func_space)
@@ -130,6 +176,12 @@ end
 end
 
 # u should be given as [x, y, z, x, y, z, ...]
+"""
+    function_vector_symmetric_gradient!(grad::Matrix, fe_v, q_point::Int, u::Vector) -> sym_gradient
+
+Computes the symmetric gradient (jacobian) in a quadrature point for a vector valued function.
+Result is stored in `grad`.
+"""
 @inline function function_vector_symmetric_gradient!{T}(grad::Matrix{T}, fe_v::FEValues, q_point::Int, u::Vector{T})
     func_space = get_functionspace(fe_v)
     n_base_funcs = n_basefunctions(func_space)
@@ -155,6 +207,11 @@ end
 end
 
 # u should be given as [x, y, z, x, y, z, ...]
+"""
+    function_vector_divergence(fe_v, q_point::Int, u::Vector) -> divergence
+
+Computes the divergence in a quadrature point for a vector valued function.
+"""
 @inline function function_vector_divergence{T}(fe_v::FEValues, q_point::Int, u::Vector{T})
     func_space = get_functionspace(fe_v)
     n_base_funcs = n_basefunctions(func_space)

--- a/src/utilities/function_spaces.jl
+++ b/src/utilities/function_spaces.jl
@@ -216,6 +216,9 @@ function derivative!(::Lagrange{1, Triangle}, dN::Matrix, ξ::Vector)
     return dN
 end
 
+
+n_basefunctions(::Lagrange{2, Triangle}) = 6
+
 """
 Computes the shape functions at a point for
 a quadratic triangle element

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ else
     const Test = BaseTestNext
 end
 
-#include("test_elements.jl")
-#include("test_materials.jl")
-#include("test_utilities.jl")
+include("test_elements.jl")
+include("test_materials.jl")
+include("test_utilities.jl")
 include("test_fevalues.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,7 @@ else
     const Test = BaseTestNext
 end
 
-# write your own tests here
-include("test_elements.jl")
-include("test_materials.jl")
-include("test_utilities.jl")
+#include("test_elements.jl")
+#include("test_materials.jl")
+#include("test_utilities.jl")
 include("test_fevalues.jl")

--- a/test/test_fevalues.jl
+++ b/test/test_fevalues.jl
@@ -97,20 +97,25 @@ end
         # We test this by applying a given deformation gradient on all the nodes.
         # Since this is a linear deformation we should get back the exact values
         # from the interpolation.
-        cx = rand()
-        cy = rand()
         u = zeros(ndim * n_basefuncs)
+        u_scal = zeros(n_basefuncs)
         H = rand(ndim, ndim)
+        V = rand(ndim)
         for i in 1:n_basefuncs
             a = x[:, i]
             u[ndim*(i-1) + 1:ndim*(i-1) + ndim] = H * a
+            u_scal[i] = dot(a, V)
         end
 
         m = zeros(ndim, ndim)
+        grad = zeros(ndim)
         for i in 1:length(JuAFEM.points(quad_rule))
             @test function_vector_gradient!(m, fev, i, u) ≈ H
             @test function_vector_symmetric_gradient!(m, fev, i, u) ≈ 0.5(H + H')
             @test function_vector_divergence(fev, i, u) ≈ trace(H)
+            @test function_scalar_gradient!(grad, fev, i, u_scal) ≈ V
+            function_scalar_value(fev, i, u_scal)
+            function_vector_value!(grad, fev, i, u)
         end
     end
 

--- a/test/test_fevalues.jl
+++ b/test/test_fevalues.jl
@@ -88,7 +88,7 @@ end
                                          (Serendipity{2, Square}(), JuAFEM.get_gaussrule(Square(), 2)))
 
 
-        fev = FEValues(Float64, quad_rule, function_space)
+        fev = FEValues(quad_rule, function_space)
         ndim = n_dim(function_space)
         n_basefuncs = n_basefunctions(function_space)
         x = rand(ndim, n_basefuncs)


### PR DESCRIPTION
This is a work in progress to simplify taking operators on vector / scalar fields defined on the nodes in a finite element.
Currently, the functions that return second order tensors return them in matrix form but I should add so they can be returned in Voigt form as well.

The way these functions work is basically how you write them in math with a sum over all base functions etc etc.
The nice thing is that they tend to be significantly quicker than the "FEM Basics" way where you create a B-matrix or N-matrix and matrix multiply.
For a 8 node quadraterial the `function_vector_symmetric_gradient` is about 3x faster than creating the B-matrix and doing the B * u matrix multiplication

TODO:

- [ ] Look a bit on the performance by changing the loop order
- [ ] Test the functions that return a scalar
- [ ] Maybe create an example that uses this.

This PR also changes the function name `shape_derivative` to `shape_gradient` but the old name is kept for a while.