### PR TITLE
make function space parameterized on dim

### DIFF
--- a/src/JuAFEM.jl
+++ b/src/JuAFEM.jl
@@ -35,7 +35,7 @@ export FEValues, reinit!, shape_value, shape_gradient, detJdV, get_quadrule, get
                  function_vector_gradient!, function_vector_divergence, function_vector_symmetric_gradient!
 export n_dim, n_basefunctions
 export Lagrange, Serendipity
-export get_gaussrule
+export get_gaussrule, Dim
 
 include("materials/hooke.jl")
 include("utilities/utilities.jl")

--- a/src/JuAFEM.jl
+++ b/src/JuAFEM.jl
@@ -34,7 +34,7 @@ export FEValues, reinit!, shape_value, shape_gradient, detJdV, get_quadrule, get
                  function_scalar_value, function_vector_value!, function_scalar_gradient!,
                  function_vector_gradient!, function_vector_divergence, function_vector_symmetric_gradient!
 export n_dim, n_basefunctions
-export Lagrange, Serenipity
+export Lagrange, Serendipity
 export get_gaussrule
 
 include("materials/hooke.jl")

--- a/src/elements/elements.jl
+++ b/src/elements/elements.jl
@@ -45,7 +45,7 @@ function gen_ke_fe_body(ele)
 
         # Create the gauss rule of the requested order on the
         # elements reference shape
-        qr = get_gaussrule($(ref_shape(ele.function_space)), ndim, int_order)
+        qr = get_gaussrule(ndim, $(ref_shape(ele.function_space)), int_order)
 
         for (ξ, w) in zip(qr.points, qr.weights)
             value!($(ele.function_space), N, ξ)
@@ -124,7 +124,7 @@ function gen_s_body(ele)
 
         # Create the gauss rule of the requested order on the
         # elements reference shape
-        qr = get_gaussrule($(ref_shape(ele.function_space)), ndim, int_order)
+        qr = get_gaussrule(ndim, $(ref_shape(ele.function_space)), int_order)
 
         n_gps = length(qr.points)
         FLUXES = zeros(fluxlen, n_gps)
@@ -200,7 +200,7 @@ function gen_f_body(ele)
 
         # Create the gauss rule of the requested order on the
         # elements reference shape
-        qr = get_gaussrule($(ref_shape(ele.function_space)), ndim, int_order)
+        qr = get_gaussrule(ndim, $(ref_shape(ele.function_space)), int_order)
 
         if size(σs, 2) != length(qr.points)
             throw(ArgumentError("must use same integration rule to compute stresses and internal forces"))

--- a/src/elements/elements.jl
+++ b/src/elements/elements.jl
@@ -45,7 +45,7 @@ function gen_ke_fe_body(ele)
 
         # Create the gauss rule of the requested order on the
         # elements reference shape
-        qr = get_gaussrule($(ele.shape), int_order)
+        qr = get_gaussrule($(ref_shape(ele.function_space)), ndim, int_order)
 
         for (ξ, w) in zip(qr.points, qr.weights)
             value!($(ele.function_space), N, ξ)
@@ -124,7 +124,7 @@ function gen_s_body(ele)
 
         # Create the gauss rule of the requested order on the
         # elements reference shape
-        qr = get_gaussrule($(ele.shape), int_order)
+        qr = get_gaussrule($(ref_shape(ele.function_space)), ndim, int_order)
 
         n_gps = length(qr.points)
         FLUXES = zeros(fluxlen, n_gps)
@@ -200,7 +200,7 @@ function gen_f_body(ele)
 
         # Create the gauss rule of the requested order on the
         # elements reference shape
-        qr = get_gaussrule($(ele.shape), int_order)
+        qr = get_gaussrule($(ref_shape(ele.function_space)), ndim, int_order)
 
         if size(σs, 2) != length(qr.points)
             throw(ArgumentError("must use same integration rule to compute stresses and internal forces"))

--- a/src/elements/elements.jl
+++ b/src/elements/elements.jl
@@ -45,7 +45,7 @@ function gen_ke_fe_body(ele)
 
         # Create the gauss rule of the requested order on the
         # elements reference shape
-        qr = get_gaussrule(ndim, $(ref_shape(ele.function_space)), int_order)
+        qr = get_gaussrule(Dim{$(n_dim(ele))}, $(ref_shape(ele.function_space)), int_order)
 
         for (ξ, w) in zip(qr.points, qr.weights)
             value!($(ele.function_space), N, ξ)
@@ -124,7 +124,7 @@ function gen_s_body(ele)
 
         # Create the gauss rule of the requested order on the
         # elements reference shape
-        qr = get_gaussrule(ndim, $(ref_shape(ele.function_space)), int_order)
+        qr = get_gaussrule(Dim{$(n_dim(ele))}, $(ref_shape(ele.function_space)), int_order)
 
         n_gps = length(qr.points)
         FLUXES = zeros(fluxlen, n_gps)
@@ -200,7 +200,7 @@ function gen_f_body(ele)
 
         # Create the gauss rule of the requested order on the
         # elements reference shape
-        qr = get_gaussrule(ndim, $(ref_shape(ele.function_space)), int_order)
+        qr = get_gaussrule(Dim{$(n_dim(ele))}, $(ref_shape(ele.function_space)), int_order)
 
         if size(σs, 2) != length(qr.points)
             throw(ArgumentError("must use same integration rule to compute stresses and internal forces"))

--- a/src/elements/heat_elements.jl
+++ b/src/elements/heat_elements.jl
@@ -39,7 +39,7 @@ end
 
 H_S_1 = FElement(
     :heat_square_1,
-    Lagrange{1, Square, 2}(),
+    Lagrange{2, Square, 1}(),
     get_default_heat_vars(4, 2),
     4,
     1,
@@ -65,7 +65,7 @@ H_S_2 = FElement(
 
 H_T_1 = FElement(
     :heat_tri_1,
-    Lagrange{1, Triangle, 2}(),
+    Lagrange{2, Triangle, 1}(),
     get_default_heat_vars(3, 2),
     3,
     1,
@@ -78,7 +78,7 @@ H_T_1 = FElement(
 
 H_C_1 = FElement(
     :heat_cube_1,
-    Lagrange{1, Square, 3}(),
+    Lagrange{3, Square, 1}(),
     get_default_heat_vars(8, 3),
     8,
     1,

--- a/src/elements/heat_elements.jl
+++ b/src/elements/heat_elements.jl
@@ -39,8 +39,7 @@ end
 
 H_S_1 = FElement(
     :heat_square_1,
-    Square(),
-    Lagrange{1, Square}(),
+    Lagrange{1, Square, 2}(),
     get_default_heat_vars(4, 2),
     4,
     1,
@@ -53,8 +52,7 @@ H_S_1 = FElement(
 
 H_S_2 = FElement(
     :heat_square_2,
-    Square(),
-    Serendipity{2, Square}(),
+    Serendipity{2, Square, 2}(),
     get_default_heat_vars(8, 2),
     8,
     1,
@@ -67,8 +65,7 @@ H_S_2 = FElement(
 
 H_T_1 = FElement(
     :heat_tri_1,
-    Triangle(),
-    Lagrange{1, Triangle}(),
+    Lagrange{1, Triangle, 2}(),
     get_default_heat_vars(3, 2),
     3,
     1,
@@ -81,8 +78,7 @@ H_T_1 = FElement(
 
 H_C_1 = FElement(
     :heat_cube_1,
-    Cube(),
-    Lagrange{1, Cube}(),
+    Lagrange{1, Square, 3}(),
     get_default_heat_vars(8, 3),
     8,
     1,

--- a/src/elements/solid_elements.jl
+++ b/src/elements/solid_elements.jl
@@ -90,8 +90,7 @@ end
 
 S_S_1 = FElement(
     :solid_square_1,
-    Square(),
-    Lagrange{1, Square}(),
+    Lagrange{1, Square, 2}(),
     get_default_contmech_vars(4, 2),
     4,
     2,
@@ -106,8 +105,7 @@ S_S_1 = FElement(
 
 S_S_2 = FElement(
     :solid_square_2,
-    Square(),
-    Serendipity{2, Square}(),
+    Serendipity{2, Square, 2}(),
     get_default_contmech_vars(8, 2),
     8,
     2,
@@ -122,8 +120,7 @@ S_S_2 = FElement(
 
 S_T_1 = FElement(
     :solid_tri_1,
-    Triangle(),
-    Lagrange{1, Triangle}(),
+    Lagrange{1, Triangle, 2}(),
     get_default_contmech_vars(3, 2),
     3,
     2,
@@ -138,8 +135,7 @@ S_T_1 = FElement(
 
 S_C_1 = FElement(
     :solid_cube_1,
-    Cube(),
-    Lagrange{1, Cube}(),
+    Lagrange{1, Square, 3}(),
     get_default_contmech_vars(8, 3),
     8,
     3,

--- a/src/elements/solid_elements.jl
+++ b/src/elements/solid_elements.jl
@@ -90,7 +90,7 @@ end
 
 S_S_1 = FElement(
     :solid_square_1,
-    Lagrange{1, Square, 2}(),
+    Lagrange{2, Square, 1}(),
     get_default_contmech_vars(4, 2),
     4,
     2,
@@ -120,7 +120,7 @@ S_S_2 = FElement(
 
 S_T_1 = FElement(
     :solid_tri_1,
-    Lagrange{1, Triangle, 2}(),
+    Lagrange{2, Triangle, 1}(),
     get_default_contmech_vars(3, 2),
     3,
     2,
@@ -135,7 +135,7 @@ S_T_1 = FElement(
 
 S_C_1 = FElement(
     :solid_cube_1,
-    Lagrange{1, Square, 3}(),
+    Lagrange{3, Square, 1}(),
     get_default_contmech_vars(8, 3),
     8,
     3,

--- a/src/utilities/finite_element.jl
+++ b/src/utilities/finite_element.jl
@@ -1,7 +1,6 @@
 # TODO document this
 immutable FElement{FS <: FunctionSpace}
     name::Symbol
-    shape::GeoShape
     function_space::FS
     inits::Dict{Symbol, NTuple{2, Int}}
     nnodes::Int
@@ -14,13 +13,12 @@ immutable FElement{FS <: FunctionSpace}
     default_intorder::Int # Should give a full rank stiffness matrix
 end
 
-n_dim(fele::FElement) = n_dim(fele.shape)
+n_dim(fele::FElement) = n_dim(fele.function_space)
 n_flux(fele::FElement) = fele.flux_size
 
 function show(io::IO, fele::FElement)
     print(io, "Name: $(fele.name)\n")
-    print(io, "Reference shape: $(typeof(fele.shape))\n")
-    print(io, "Shape functions: $(typeof(fele.shape_funcs))\n")
+    print(io, "Shape function: $(typeof(fele.shape_funcs))\n")
     print(io, "Number of nodes: $(fele.nnodes)\n")
     print(io, "Dofs per node: $(fele.dofs_per_node)")
 end

--- a/src/utilities/function_spaces.jl
+++ b/src/utilities/function_spaces.jl
@@ -1,21 +1,20 @@
-abstract FunctionSpace{order, shape}
+abstract FunctionSpace{order, shape, dim}
 
-@inline n_dim(fs::FunctionSpace) = n_dim(ref_shape(fs))
-
-@inline ref_shape{order, shape}(fs::FunctionSpace{order, shape}) = shape()
-@inline order{order, shape}(fs::FunctionSpace{order, shape}) = order
+@inline n_dim{order, shape, dim}(fs::FunctionSpace{order, shape, dim}) = dim
+@inline ref_shape{order, shape, dim}(fs::FunctionSpace{order, shape, dim}) = shape()
+@inline order{order, shape, dim}(fs::FunctionSpace{order, shape, dim}) = order
 
 """
 Computes the value of the shape functions at a point ξ for a given function space
 """
-function value{order, shape}(fs::FunctionSpace{order, shape}, ξ::Vector)
+function value{order, shape, dim}(fs::FunctionSpace{order, shape, dim}, ξ::Vector)
     value!(fs, zeros(eltype(ξ), n_basefunctions(fs)), ξ)
 end
 
 """
 Computes the gradients of the shape functions at a point ξ for a given function space
 """
-function derivative{order, shape}(fs::FunctionSpace{order, shape}, ξ::Vector)
+function derivative{order, shape, dim}(fs::FunctionSpace{order, shape, dim}, ξ::Vector)
     derivative!(fs, zeros(eltype(ξ), n_dim(fs), n_basefunctions(fs)), ξ)
 end
 
@@ -23,15 +22,15 @@ end
 # Lagrange
 ############
 
-type Lagrange{order, shape} <: FunctionSpace{order, shape} end
+type Lagrange{order, shape, dim} <: FunctionSpace{order, shape, dim} end
 
-#################
-# Lagrange 1 Line
-#################
+#####################
+# Lagrange 1 Square #
+#####################
 
-n_basefunctions(::Lagrange{1, Line}) = 2
+n_basefunctions(::Lagrange{1, Square, 1}) = 2
 
-function value!(::Lagrange{1, Line}, N::Vector, ξ::Vector)
+function value!(::Lagrange{1, Square, 1}, N::Vector, ξ::Vector)
     length(N) == 2 || throw(ArgumentError("N must have length 2"))
     length(ξ) == 1 || throw(ArgumentError("ξ must have length 1"))
 
@@ -45,7 +44,7 @@ function value!(::Lagrange{1, Line}, N::Vector, ξ::Vector)
     return N
 end
 
-function derivative!(::Lagrange{1, Line}, dN::Matrix, ξ::Vector)
+function derivative!(::Lagrange{1, Square, 1}, dN::Matrix, ξ::Vector)
     size(dN) == (1,2) || throw(ArgumentError("dN must have size (1,2)"))
     length(ξ) == 1 || throw(ArgumentError("ξ must have length 1"))
 
@@ -59,13 +58,13 @@ function derivative!(::Lagrange{1, Line}, dN::Matrix, ξ::Vector)
     return dN
 end
 
-#################
-# Lagrange 2 Line
-#################
+#####################
+# Lagrange 2 Square #
+#####################
 
-n_basefunctions(::Lagrange{2, Line}) = 3
+n_basefunctions(::Lagrange{2, Square, 1}) = 3
 
-function value!(::Lagrange{2, Line}, N::Vector, ξ::Vector)
+function value!(::Lagrange{2, Square, 1}, N::Vector, ξ::Vector)
     length(N) == 3 || throw(ArgumentError("N must have length 3"))
     length(ξ) == 1 || throw(ArgumentError("ξ must have length 1"))
 
@@ -82,7 +81,7 @@ end
 
 
 
-function derivative!(::Lagrange{2, Line}, dN::Matrix, ξ::Vector)
+function derivative!(::Lagrange{2, Square, 1}, dN::Matrix, ξ::Vector)
     size(dN) == (1,3) || throw(ArgumentError("dN must have size (1,3)"))
     length(ξ) == 1 || throw(ArgumentError("ξ must have length 1"))
 
@@ -101,9 +100,9 @@ end
 # Lagrange 1 Square
 ###################
 
-n_basefunctions(::Lagrange{1, Square}) = 4
+n_basefunctions(::Lagrange{1, Square, 2}) = 4
 
-function value!(::Lagrange{1, Square}, N::Vector, ξ::Vector)
+function value!(::Lagrange{1, Square, 2}, N::Vector, ξ::Vector)
     length(N) == 4 || throw(ArgumentError("N must have length 4"))
     length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
 
@@ -120,7 +119,7 @@ function value!(::Lagrange{1, Square}, N::Vector, ξ::Vector)
     return N
 end
 
-function derivative!(::Lagrange{1, Square}, dN::Matrix, ξ::Vector)
+function derivative!(::Lagrange{1, Square, 2}, dN::Matrix, ξ::Vector)
     size(dN) == (2, 4) || throw(ArgumentError("dN must have size (2, 4)"))
     length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
 
@@ -148,9 +147,9 @@ end
 # Lagrange 1 Triangle
 #####################
 
-n_basefunctions(::Lagrange{1, Triangle}) = 3
+n_basefunctions(::Lagrange{1, Triangle, 2}) = 3
 
-function value!(::Lagrange{1, Triangle}, N::Vector, ξ::Vector)
+function value!(::Lagrange{1, Triangle, 2}, N::Vector, ξ::Vector)
     length(N) == 3 || throw(ArgumentError("N must have length 3"))
     length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
 
@@ -166,7 +165,7 @@ function value!(::Lagrange{1, Triangle}, N::Vector, ξ::Vector)
     return N
 end
 
-function derivative!(::Lagrange{1, Triangle}, dN::Matrix, ξ::Vector)
+function derivative!(::Lagrange{1, Triangle, 2}, dN::Matrix, ξ::Vector)
     size(dN) == (2, 3) || throw(ArgumentError("dN must have size (2, 3)"))
     length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
 
@@ -188,9 +187,9 @@ end
 # Lagrange 2 Triangle
 #####################
 
-n_basefunctions(::Lagrange{2, Triangle}) = 6
+n_basefunctions(::Lagrange{2, Triangle, 2}) = 6
 
-function value!(::Lagrange{2, Triangle}, N::Vector, ξ::Vector)
+function value!(::Lagrange{2, Triangle, 2}, N::Vector, ξ::Vector)
     length(N) == 6 || throw(ArgumentError("N must have length 6"))
     length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
 
@@ -211,7 +210,7 @@ function value!(::Lagrange{2, Triangle}, N::Vector, ξ::Vector)
     return N
 end
 
-function derivative!(::Lagrange{2, Triangle}, dN::Matrix, ξ::Vector)
+function derivative!(::Lagrange{2, Triangle, 2}, dN::Matrix, ξ::Vector)
     size(dN) == (2, 6) || throw(ArgumentError("dN must have size (2, 6)"))
     length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
 
@@ -241,13 +240,13 @@ function derivative!(::Lagrange{2, Triangle}, dN::Matrix, ξ::Vector)
 end
 
 
-#################
-# Lagrange 1 Cube
-#################
+#####################
+# Lagrange 1 Square #
+#####################
 
-n_basefunctions(::Lagrange{1, Cube}) = 8
+n_basefunctions(::Lagrange{1, Square, 3}) = 8
 
-function value!(::Lagrange{1, Cube}, N::Vector, ξ::Vector)
+function value!(::Lagrange{1, Square, 3}, N::Vector, ξ::Vector)
     length(N) == 8 || throw(ArgumentError("N must have length 8"))
     length(ξ) == 3 || throw(ArgumentError("ξ must have length 3"))
 
@@ -269,7 +268,7 @@ function value!(::Lagrange{1, Cube}, N::Vector, ξ::Vector)
     return N
 end
 
-function derivative!(fs::Lagrange{1, Cube}, dN::Matrix, ξ::Vector)
+function derivative!(fs::Lagrange{1, Square, 3}, dN::Matrix, ξ::Vector)
 
     size(dN) == (3, 8) || throw(ArgumentError("dN must have size (3, 8)"))
     length(ξ) == 3 || throw(ArgumentError("ξ must have length 3"))
@@ -315,11 +314,11 @@ end
 # Serendipity Q 2
 #################
 
-type Serendipity{order, shape} <: FunctionSpace{order, shape} end
+type Serendipity{order, shape, dim} <: FunctionSpace{order, shape, dim} end
 
-n_basefunctions(::Serendipity{2, Square}) = 8
+n_basefunctions(::Serendipity{2, Square, 2}) = 8
 
-function value!(::Serendipity{2, Square}, N::Vector, ξ::Vector)
+function value!(::Serendipity{2, Square, 2}, N::Vector, ξ::Vector)
     length(N) == 8 || throw(ArgumentError("N must have length 3"))
     length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
 
@@ -339,7 +338,7 @@ function value!(::Serendipity{2, Square}, N::Vector, ξ::Vector)
     return N
 end
 
-function derivative!(::Serendipity{2, Square}, dN::Matrix, ξ::Vector)
+function derivative!(::Serendipity{2, Square, 2}, dN::Matrix, ξ::Vector)
     size(dN) == (2, 8) || throw(ArgumentError("dN must have size (2, 8)"))
     length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
 

--- a/src/utilities/function_spaces.jl
+++ b/src/utilities/function_spaces.jl
@@ -7,15 +7,27 @@ abstract FunctionSpace{dim, shape, order}
 """
 Computes the value of the shape functions at a point ξ for a given function space
 """
-function value{dim, shape, order}(fs::FunctionSpace{dim, shape, order}, ξ::Vector)
+function value(fs::FunctionSpace, ξ::Vector)
     value!(fs, zeros(eltype(ξ), n_basefunctions(fs)), ξ)
 end
 
 """
 Computes the gradients of the shape functions at a point ξ for a given function space
 """
-function derivative{dim, shape, order}(fs::FunctionSpace{dim, shape, order}, ξ::Vector)
+function derivative(fs::FunctionSpace, ξ::Vector)
     derivative!(fs, zeros(eltype(ξ), n_dim(fs), n_basefunctions(fs)), ξ)
+end
+
+@inline function checkdim_value{dim}(fs::FunctionSpace{dim}, N::Vector, ξ::Vector)
+    n_base = n_basefunctions(fs)
+    length(N) == n_base || throw(ArgumentError("N must have length $(n_base)"))
+    length(ξ) == dim || throw(ArgumentError("ξ must have length $dim"))
+end
+
+@inline function checkdim_derivative{dim}(fs::FunctionSpace{dim}, dN::Matrix, ξ::Vector)
+    n_base = n_basefunctions(fs)
+    size(dN) == (dim, n_base) || throw(ArgumentError("dN must have size ($dim, $n_base)"))
+    length(ξ) == dim || throw(ArgumentError("ξ must have length $dim"))
 end
 
 ############
@@ -30,9 +42,8 @@ type Lagrange{dim, shape, order} <: FunctionSpace{dim, shape, order} end
 
 n_basefunctions(::Lagrange{1, Square, 1}) = 2
 
-function value!(::Lagrange{1, Square, 1}, N::Vector, ξ::Vector)
-    length(N) == 2 || throw(ArgumentError("N must have length 2"))
-    length(ξ) == 1 || throw(ArgumentError("ξ must have length 1"))
+function value!(fs::Lagrange{1, Square, 1}, N::Vector, ξ::Vector)
+    checkdim_value(fs, N, ξ)
 
     @inbounds begin
         ξ_x = ξ[1]
@@ -44,9 +55,8 @@ function value!(::Lagrange{1, Square, 1}, N::Vector, ξ::Vector)
     return N
 end
 
-function derivative!(::Lagrange{1, Square, 1}, dN::Matrix, ξ::Vector)
-    size(dN) == (1,2) || throw(ArgumentError("dN must have size (1,2)"))
-    length(ξ) == 1 || throw(ArgumentError("ξ must have length 1"))
+function derivative!(fs::Lagrange{1, Square, 1}, dN::Matrix, ξ::Vector)
+    checkdim_derivative(fs, dN, ξ)
 
     @inbounds begin
         ξ_x = ξ[1]
@@ -64,9 +74,8 @@ end
 
 n_basefunctions(::Lagrange{1, Square, 2}) = 3
 
-function value!(::Lagrange{1, Square, 2}, N::Vector, ξ::Vector)
-    length(N) == 3 || throw(ArgumentError("N must have length 3"))
-    length(ξ) == 1 || throw(ArgumentError("ξ must have length 1"))
+function value!(fs::Lagrange{1, Square, 2}, N::Vector, ξ::Vector)
+    checkdim_value(fs, N, ξ)
 
     @inbounds begin
         ξ_x = ξ[1]
@@ -81,9 +90,8 @@ end
 
 
 
-function derivative!(::Lagrange{1, Square, 2}, dN::Matrix, ξ::Vector)
-    size(dN) == (1,3) || throw(ArgumentError("dN must have size (1,3)"))
-    length(ξ) == 1 || throw(ArgumentError("ξ must have length 1"))
+function derivative!(fs::Lagrange{1, Square, 2}, dN::Matrix, ξ::Vector)
+    checkdim_derivative(fs, dN, ξ)
 
     @inbounds begin
         ξ_x = ξ[1]
@@ -102,9 +110,8 @@ end
 
 n_basefunctions(::Lagrange{2, Square, 1}) = 4
 
-function value!(::Lagrange{2, Square, 1}, N::Vector, ξ::Vector)
-    length(N) == 4 || throw(ArgumentError("N must have length 4"))
-    length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
+function value!(fs::Lagrange{2, Square, 1}, N::Vector, ξ::Vector)
+    checkdim_value(fs, N, ξ)
 
     @inbounds begin
         ξ_x = ξ[1]
@@ -119,9 +126,8 @@ function value!(::Lagrange{2, Square, 1}, N::Vector, ξ::Vector)
     return N
 end
 
-function derivative!(::Lagrange{2, Square, 1}, dN::Matrix, ξ::Vector)
-    size(dN) == (2, 4) || throw(ArgumentError("dN must have size (2, 4)"))
-    length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
+function derivative!(fs::Lagrange{2, Square, 1}, dN::Matrix, ξ::Vector)
+    checkdim_derivative(fs, dN, ξ)
 
     @inbounds begin
         ξ_x = ξ[1]
@@ -149,9 +155,8 @@ end
 
 n_basefunctions(::Lagrange{2, Triangle, 1}) = 3
 
-function value!(::Lagrange{2, Triangle, 1}, N::Vector, ξ::Vector)
-    length(N) == 3 || throw(ArgumentError("N must have length 3"))
-    length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
+function value!(fs::Lagrange{2, Triangle, 1}, N::Vector, ξ::Vector)
+    checkdim_value(fs, N, ξ)
 
     @inbounds begin
         ξ_x = ξ[1]
@@ -165,9 +170,8 @@ function value!(::Lagrange{2, Triangle, 1}, N::Vector, ξ::Vector)
     return N
 end
 
-function derivative!(::Lagrange{2, Triangle, 1}, dN::Matrix, ξ::Vector)
-    size(dN) == (2, 3) || throw(ArgumentError("dN must have size (2, 3)"))
-    length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
+function derivative!(fs::Lagrange{2, Triangle, 1}, dN::Matrix, ξ::Vector)
+    checkdim_derivative(fs, dN, ξ)
 
     @inbounds begin
         dN[1,1] =  1.0
@@ -189,9 +193,8 @@ end
 
 n_basefunctions(::Lagrange{2, Triangle, 2}) = 6
 
-function value!(::Lagrange{2, Triangle, 2}, N::Vector, ξ::Vector)
-    length(N) == 6 || throw(ArgumentError("N must have length 6"))
-    length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
+function value!(fs::Lagrange{2, Triangle, 2}, N::Vector, ξ::Vector)
+    checkdim_value(fs, N, ξ)
 
     @inbounds begin
         ξ_x = ξ[1]
@@ -210,9 +213,8 @@ function value!(::Lagrange{2, Triangle, 2}, N::Vector, ξ::Vector)
     return N
 end
 
-function derivative!(::Lagrange{2, Triangle, 2}, dN::Matrix, ξ::Vector)
-    size(dN) == (2, 6) || throw(ArgumentError("dN must have size (2, 6)"))
-    length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
+function derivative!(fs::Lagrange{2, Triangle, 2}, dN::Matrix, ξ::Vector)
+    checkdim_derivative(fs, dN, ξ)
 
     @inbounds begin
 
@@ -246,9 +248,8 @@ end
 
 n_basefunctions(::Lagrange{3, Square, 1}) = 8
 
-function value!(::Lagrange{3, Square, 1}, N::Vector, ξ::Vector)
-    length(N) == 8 || throw(ArgumentError("N must have length 8"))
-    length(ξ) == 3 || throw(ArgumentError("ξ must have length 3"))
+function value!(fs::Lagrange{3, Square, 1}, N::Vector, ξ::Vector)
+    checkdim_value(fs, N, ξ)
 
     @inbounds begin
         ξ_x = ξ[1]
@@ -269,9 +270,7 @@ function value!(::Lagrange{3, Square, 1}, N::Vector, ξ::Vector)
 end
 
 function derivative!(fs::Lagrange{3, Square, 1}, dN::Matrix, ξ::Vector)
-
-    size(dN) == (3, 8) || throw(ArgumentError("dN must have size (3, 8)"))
-    length(ξ) == 3 || throw(ArgumentError("ξ must have length 3"))
+    checkdim_derivative(fs, dN, ξ)
 
     @inbounds begin
         ξ_x = ξ[1]
@@ -318,9 +317,8 @@ type Serendipity{dim, shape, order} <: FunctionSpace{dim, shape, order} end
 
 n_basefunctions(::Serendipity{2, Square, 2}) = 8
 
-function value!(::Serendipity{2, Square, 2}, N::Vector, ξ::Vector)
-    length(N) == 8 || throw(ArgumentError("N must have length 3"))
-    length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
+function value!(fs::Serendipity{2, Square, 2}, N::Vector, ξ::Vector)
+    checkdim_value(fs, N, ξ)
 
     ξ_x = ξ[1]
     ξ_y = ξ[2]
@@ -338,9 +336,8 @@ function value!(::Serendipity{2, Square, 2}, N::Vector, ξ::Vector)
     return N
 end
 
-function derivative!(::Serendipity{2, Square, 2}, dN::Matrix, ξ::Vector)
-    size(dN) == (2, 8) || throw(ArgumentError("dN must have size (2, 8)"))
-    length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
+function derivative!(fs::Serendipity{2, Square, 2}, dN::Matrix, ξ::Vector)
+    checkdim_derivative(fs, dN, ξ)
 
     ξ_x = ξ[1]
     ξ_y = ξ[2]

--- a/src/utilities/function_spaces.jl
+++ b/src/utilities/function_spaces.jl
@@ -1,20 +1,20 @@
-abstract FunctionSpace{order, shape, dim}
+abstract FunctionSpace{dim, shape, order}
 
-@inline n_dim{order, shape, dim}(fs::FunctionSpace{order, shape, dim}) = dim
-@inline ref_shape{order, shape, dim}(fs::FunctionSpace{order, shape, dim}) = shape()
-@inline order{order, shape, dim}(fs::FunctionSpace{order, shape, dim}) = order
+@inline n_dim{dim, shape, order}(fs::FunctionSpace{dim, shape, order}) = dim
+@inline ref_shape{order, shape, dim}(fs::FunctionSpace{dim, shape, order}) = shape()
+@inline order{dim, shape, order}(fs::FunctionSpace{dim, shape, order}) = order
 
 """
 Computes the value of the shape functions at a point ξ for a given function space
 """
-function value{order, shape, dim}(fs::FunctionSpace{order, shape, dim}, ξ::Vector)
+function value{dim, shape, order}(fs::FunctionSpace{dim, shape, order}, ξ::Vector)
     value!(fs, zeros(eltype(ξ), n_basefunctions(fs)), ξ)
 end
 
 """
 Computes the gradients of the shape functions at a point ξ for a given function space
 """
-function derivative{order, shape, dim}(fs::FunctionSpace{order, shape, dim}, ξ::Vector)
+function derivative{dim, shape, order}(fs::FunctionSpace{dim, shape, order}, ξ::Vector)
     derivative!(fs, zeros(eltype(ξ), n_dim(fs), n_basefunctions(fs)), ξ)
 end
 
@@ -22,11 +22,11 @@ end
 # Lagrange
 ############
 
-type Lagrange{order, shape, dim} <: FunctionSpace{order, shape, dim} end
+type Lagrange{dim, shape, order} <: FunctionSpace{dim, shape, order} end
 
-#####################
-# Lagrange 1 Square #
-#####################
+#################################
+# Lagrange dim 1 Square order 1 #
+#################################
 
 n_basefunctions(::Lagrange{1, Square, 1}) = 2
 
@@ -58,13 +58,13 @@ function derivative!(::Lagrange{1, Square, 1}, dN::Matrix, ξ::Vector)
     return dN
 end
 
-#####################
-# Lagrange 2 Square #
-#####################
+#################################
+# Lagrange dim 1 Square order 2 #
+#################################
 
-n_basefunctions(::Lagrange{2, Square, 1}) = 3
+n_basefunctions(::Lagrange{1, Square, 2}) = 3
 
-function value!(::Lagrange{2, Square, 1}, N::Vector, ξ::Vector)
+function value!(::Lagrange{1, Square, 2}, N::Vector, ξ::Vector)
     length(N) == 3 || throw(ArgumentError("N must have length 3"))
     length(ξ) == 1 || throw(ArgumentError("ξ must have length 1"))
 
@@ -81,7 +81,7 @@ end
 
 
 
-function derivative!(::Lagrange{2, Square, 1}, dN::Matrix, ξ::Vector)
+function derivative!(::Lagrange{1, Square, 2}, dN::Matrix, ξ::Vector)
     size(dN) == (1,3) || throw(ArgumentError("dN must have size (1,3)"))
     length(ξ) == 1 || throw(ArgumentError("ξ must have length 1"))
 
@@ -96,13 +96,13 @@ function derivative!(::Lagrange{2, Square, 1}, dN::Matrix, ξ::Vector)
     return dN
 end
 
-###################
-# Lagrange 1 Square
-###################
+#################################
+# Lagrange dim 2 Square order 1 #
+#################################
 
-n_basefunctions(::Lagrange{1, Square, 2}) = 4
+n_basefunctions(::Lagrange{2, Square, 1}) = 4
 
-function value!(::Lagrange{1, Square, 2}, N::Vector, ξ::Vector)
+function value!(::Lagrange{2, Square, 1}, N::Vector, ξ::Vector)
     length(N) == 4 || throw(ArgumentError("N must have length 4"))
     length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
 
@@ -119,7 +119,7 @@ function value!(::Lagrange{1, Square, 2}, N::Vector, ξ::Vector)
     return N
 end
 
-function derivative!(::Lagrange{1, Square, 2}, dN::Matrix, ξ::Vector)
+function derivative!(::Lagrange{2, Square, 1}, dN::Matrix, ξ::Vector)
     size(dN) == (2, 4) || throw(ArgumentError("dN must have size (2, 4)"))
     length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
 
@@ -143,13 +143,13 @@ function derivative!(::Lagrange{1, Square, 2}, dN::Matrix, ξ::Vector)
     return dN
 end
 
-#####################
-# Lagrange 1 Triangle
-#####################
+###################################
+# Lagrange dim 2 Triangle order 1 #
+###################################
 
-n_basefunctions(::Lagrange{1, Triangle, 2}) = 3
+n_basefunctions(::Lagrange{2, Triangle, 1}) = 3
 
-function value!(::Lagrange{1, Triangle, 2}, N::Vector, ξ::Vector)
+function value!(::Lagrange{2, Triangle, 1}, N::Vector, ξ::Vector)
     length(N) == 3 || throw(ArgumentError("N must have length 3"))
     length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
 
@@ -165,7 +165,7 @@ function value!(::Lagrange{1, Triangle, 2}, N::Vector, ξ::Vector)
     return N
 end
 
-function derivative!(::Lagrange{1, Triangle, 2}, dN::Matrix, ξ::Vector)
+function derivative!(::Lagrange{2, Triangle, 1}, dN::Matrix, ξ::Vector)
     size(dN) == (2, 3) || throw(ArgumentError("dN must have size (2, 3)"))
     length(ξ) == 2 || throw(ArgumentError("ξ must have length 2"))
 
@@ -183,9 +183,9 @@ function derivative!(::Lagrange{1, Triangle, 2}, dN::Matrix, ξ::Vector)
     return dN
 end
 
-#####################
-# Lagrange 2 Triangle
-#####################
+###################################
+# Lagrange dim 2 Triangle order 2 #
+###################################
 
 n_basefunctions(::Lagrange{2, Triangle, 2}) = 6
 
@@ -240,13 +240,13 @@ function derivative!(::Lagrange{2, Triangle, 2}, dN::Matrix, ξ::Vector)
 end
 
 
-#####################
-# Lagrange 1 Square #
-#####################
+###################################
+# Lagrange dim 3 Square order 1 #
+###################################
 
-n_basefunctions(::Lagrange{1, Square, 3}) = 8
+n_basefunctions(::Lagrange{3, Square, 1}) = 8
 
-function value!(::Lagrange{1, Square, 3}, N::Vector, ξ::Vector)
+function value!(::Lagrange{3, Square, 1}, N::Vector, ξ::Vector)
     length(N) == 8 || throw(ArgumentError("N must have length 8"))
     length(ξ) == 3 || throw(ArgumentError("ξ must have length 3"))
 
@@ -268,7 +268,7 @@ function value!(::Lagrange{1, Square, 3}, N::Vector, ξ::Vector)
     return N
 end
 
-function derivative!(fs::Lagrange{1, Square, 3}, dN::Matrix, ξ::Vector)
+function derivative!(fs::Lagrange{3, Square, 1}, dN::Matrix, ξ::Vector)
 
     size(dN) == (3, 8) || throw(ArgumentError("dN must have size (3, 8)"))
     length(ξ) == 3 || throw(ArgumentError("ξ must have length 3"))
@@ -310,11 +310,11 @@ function derivative!(fs::Lagrange{1, Square, 3}, dN::Matrix, ξ::Vector)
 end
 
 
-#################
-# Serendipity Q 2
-#################
+####################################
+# Serendipity dim 2 Square order 2 #
+####################################
 
-type Serendipity{order, shape, dim} <: FunctionSpace{order, shape, dim} end
+type Serendipity{dim, shape, order} <: FunctionSpace{dim, shape, order} end
 
 n_basefunctions(::Serendipity{2, Square, 2}) = 8
 

--- a/src/utilities/geometry_types.jl
+++ b/src/utilities/geometry_types.jl
@@ -1,14 +1,4 @@
-abstract GeoShape
-abstract GeoShape_3D <: GeoShape
-abstract GeoShape_2D <: GeoShape
-abstract GeoShape_1D <: GeoShape
+abstract Shape
 
-n_dim(::GeoShape_3D) = 3
-n_dim(::GeoShape_2D) = 2
-n_dim(::GeoShape_1D) = 1
-
-immutable Line <: GeoShape_1D end
-immutable Triangle <: GeoShape_2D end
-immutable Square <: GeoShape_2D end
-immutable Cube <: GeoShape_3D end
-immutable Tetrahedra <: GeoShape_3D end
+immutable Triangle <: Shape end
+immutable Square <: Shape end

--- a/src/utilities/geometry_types.jl
+++ b/src/utilities/geometry_types.jl
@@ -1,4 +1,6 @@
 abstract Shape
 
+immutable Dim{T} end
+
 immutable Triangle <: Shape end
 immutable Square <: Shape end

--- a/src/utilities/quadrature.jl
+++ b/src/utilities/quadrature.jl
@@ -25,46 +25,37 @@ function integrate(qr::QuadratureRule, f)
 end
 
 
-function get_gaussrule(dim::Int, ::Triangle, order::Int)
-    if dim == 2
-        if order <= 5
-            return trirules[order]
-        else
-            return make_trirule(order)
-        end
+function get_gaussrule(::Type{Dim{2}}, ::Triangle, order::Int)
+    if order <= 5
+        return trirules[order]
     else
-        throw(ArgumentError("triangle gauss rules only available for 2D"))
+        return make_trirule(order)
     end
 end
 
-function get_gaussrule(dim::Int, ::Square, order::Int)
-    if dim == 1
-        if order <= 5
-            return linerules[order]
-        else
-            return make_linerule(order)
-        end
-    end
-
-    if dim == 2
-        if order <= 5
-            return quadrules[order]
-        else
-            return make_quadrule(order)
-        end
-    end
-
-    if dim == 3
-        if order <= 5
-            return cuberules[order]
-        else
-            return make_cuberule(order)
-        end
+function get_gaussrule(::Type{Dim{1}}, ::Square, order::Int)
+    if order <= 5
+        return linerules[order]
+    else
+        return make_linerule(order)
     end
 end
 
+function get_gaussrule(::Type{Dim{2}}, ::Square, order::Int)
+    if order <= 5
+        return quadrules[order]
+    else
+        return make_quadrule(order)
+    end
+end
 
-
+function get_gaussrule(::Type{Dim{3}}, ::Square, order::Int)
+    if order <= 5
+        return cuberules[order]
+    else
+        return make_cuberule(order)
+    end
+end
 
 
 """

--- a/src/utilities/quadrature.jl
+++ b/src/utilities/quadrature.jl
@@ -24,10 +24,48 @@ function integrate(qr::QuadratureRule, f)
     return I
 end
 
-get_gaussrule(::Line, order::Int) = get_linerule(order)
-get_gaussrule(::Triangle, order::Int) = get_trirule(order)
-get_gaussrule(::Square, order::Int) = get_quadrule(order)
-get_gaussrule(::Cube, order::Int) = get_cuberule(order)
+
+function get_gaussrule(::Triangle, dim::Int, order::Int)
+    if dim == 2
+        if order <= 5
+            return trirules[order]
+        else
+            return make_trirule(order)
+        end
+    else
+        throw(ArgumentError("triangle gauss rules only available for 2D"))
+    end
+end
+
+function get_gaussrule(::Square, dim::Int, order::Int)
+    if dim == 1
+        if order <= 5
+            return linerules[order]
+        else
+            return make_linerule(order)
+        end
+    end
+
+    if dim == 2
+        if order <= 5
+            return quadrules[order]
+        else
+            return make_quadrule(order)
+        end
+    end
+
+    if dim == 3
+        if order <= 5
+            return cuberules[order]
+        else
+            return make_cuberule(order)
+        end
+    end
+end
+
+
+
+
 
 """
 Creates a `GaussQuadratureRule` that integrates

--- a/src/utilities/quadrature.jl
+++ b/src/utilities/quadrature.jl
@@ -25,7 +25,7 @@ function integrate(qr::QuadratureRule, f)
 end
 
 
-function get_gaussrule(::Triangle, dim::Int, order::Int)
+function get_gaussrule(dim::Int, ::Triangle, order::Int)
     if dim == 2
         if order <= 5
             return trirules[order]
@@ -37,7 +37,7 @@ function get_gaussrule(::Triangle, dim::Int, order::Int)
     end
 end
 
-function get_gaussrule(::Square, dim::Int, order::Int)
+function get_gaussrule(dim::Int, ::Square, order::Int)
     if dim == 1
         if order <= 5
             return linerules[order]

--- a/test/test_fevalues.jl
+++ b/test/test_fevalues.jl
@@ -1,5 +1,4 @@
-import JuAFEM: Square, Line, Square, Triangle, Cube,
-               Lagrange, Serendipity
+import JuAFEM: Square, Triangle
 
 
 @testset "fevalues" begin
@@ -44,8 +43,8 @@ import JuAFEM: Square, Line, Square, Triangle, Cube,
     D = hooke(2, 200e9, 0.3)
     t = 2.0
 
-    function_space = JuAFEM.Lagrange{1, JuAFEM.Square}()
-    q_rule = JuAFEM.get_gaussrule(Square(), 2)
+    function_space = JuAFEM.Lagrange{1, JuAFEM.Square, 2}()
+    q_rule = JuAFEM.get_gaussrule(Square(), 2, 2)
     fev = FEValues(Float64, q_rule, function_space)
 
 
@@ -79,13 +78,13 @@ end
 
 @testset "function interpolations" begin
 
-    for (function_space, quad_rule) in  ((Lagrange{1, Line}(), JuAFEM.get_gaussrule(Line(), 2)),
-                                         (Lagrange{2, Line}(), JuAFEM.get_gaussrule(Line(), 2)),
-                                         (Lagrange{1, Square}(), JuAFEM.get_gaussrule(Square(), 2)),
-                                         (Lagrange{1, Triangle}(), JuAFEM.get_gaussrule(Triangle(), 2)),
-                                         (Lagrange{2, Triangle}(), JuAFEM.get_gaussrule(Triangle(), 2)),
-                                         (Lagrange{1, Cube}(), JuAFEM.get_gaussrule(Cube(), 2)),
-                                         (Serendipity{2, Square}(), JuAFEM.get_gaussrule(Square(), 2)))
+    for (function_space, quad_rule) in  ((Lagrange{1, Square, 1}(), JuAFEM.get_gaussrule(Square(), 1, 2)),
+                                         (Lagrange{2, Square, 1}(), JuAFEM.get_gaussrule(Square(), 1, 2)),
+                                         (Lagrange{1, Square, 2}(), JuAFEM.get_gaussrule(Square(), 2, 2)),
+                                         (Lagrange{1, Triangle, 2}(), JuAFEM.get_gaussrule(Triangle(), 2, 2)),
+                                         (Lagrange{2, Triangle, 2}(), JuAFEM.get_gaussrule(Triangle(), 2, 2)),
+                                         (Lagrange{1, Square, 3}(), JuAFEM.get_gaussrule(Square(), 3, 2)),
+                                         (Serendipity{2, Square, 2}(), JuAFEM.get_gaussrule(Square(), 2, 2)))
 
 
         fev = FEValues(quad_rule, function_space)

--- a/test/test_fevalues.jl
+++ b/test/test_fevalues.jl
@@ -43,7 +43,7 @@ import JuAFEM: Square, Triangle
     D = hooke(2, 200e9, 0.3)
     t = 2.0
 
-    function_space = JuAFEM.Lagrange{1, JuAFEM.Square, 2}()
+    function_space = JuAFEM.Lagrange{2, JuAFEM.Square, 1}()
     q_rule = JuAFEM.get_gaussrule(Square(), 2, 2)
     fev = FEValues(Float64, q_rule, function_space)
 
@@ -79,11 +79,11 @@ end
 @testset "function interpolations" begin
 
     for (function_space, quad_rule) in  ((Lagrange{1, Square, 1}(), JuAFEM.get_gaussrule(Square(), 1, 2)),
-                                         (Lagrange{2, Square, 1}(), JuAFEM.get_gaussrule(Square(), 1, 2)),
-                                         (Lagrange{1, Square, 2}(), JuAFEM.get_gaussrule(Square(), 2, 2)),
-                                         (Lagrange{1, Triangle, 2}(), JuAFEM.get_gaussrule(Triangle(), 2, 2)),
+                                         (Lagrange{1, Square, 2}(), JuAFEM.get_gaussrule(Square(), 1, 2)),
+                                         (Lagrange{2, Square, 1}(), JuAFEM.get_gaussrule(Square(), 2, 2)),
+                                         (Lagrange{2, Triangle, 1}(), JuAFEM.get_gaussrule(Triangle(), 2, 2)),
                                          (Lagrange{2, Triangle, 2}(), JuAFEM.get_gaussrule(Triangle(), 2, 2)),
-                                         (Lagrange{1, Square, 3}(), JuAFEM.get_gaussrule(Square(), 3, 2)),
+                                         (Lagrange{3, Square, 1}(), JuAFEM.get_gaussrule(Square(), 3, 2)),
                                          (Serendipity{2, Square, 2}(), JuAFEM.get_gaussrule(Square(), 2, 2)))
 
 

--- a/test/test_fevalues.jl
+++ b/test/test_fevalues.jl
@@ -44,7 +44,7 @@ import JuAFEM: Square, Triangle
     t = 2.0
 
     function_space = JuAFEM.Lagrange{2, JuAFEM.Square, 1}()
-    q_rule = JuAFEM.get_gaussrule(Square(), 2, 2)
+    q_rule = JuAFEM.get_gaussrule(2, Square(), 2)
     fev = FEValues(Float64, q_rule, function_space)
 
 
@@ -78,13 +78,13 @@ end
 
 @testset "function interpolations" begin
 
-    for (function_space, quad_rule) in  ((Lagrange{1, Square, 1}(), JuAFEM.get_gaussrule(Square(), 1, 2)),
-                                         (Lagrange{1, Square, 2}(), JuAFEM.get_gaussrule(Square(), 1, 2)),
-                                         (Lagrange{2, Square, 1}(), JuAFEM.get_gaussrule(Square(), 2, 2)),
-                                         (Lagrange{2, Triangle, 1}(), JuAFEM.get_gaussrule(Triangle(), 2, 2)),
-                                         (Lagrange{2, Triangle, 2}(), JuAFEM.get_gaussrule(Triangle(), 2, 2)),
-                                         (Lagrange{3, Square, 1}(), JuAFEM.get_gaussrule(Square(), 3, 2)),
-                                         (Serendipity{2, Square, 2}(), JuAFEM.get_gaussrule(Square(), 2, 2)))
+    for (function_space, quad_rule) in  ((Lagrange{1, Square, 1}(), JuAFEM.get_gaussrule(1, Square(), 2)),
+                                         (Lagrange{1, Square, 2}(), JuAFEM.get_gaussrule(1, Square(), 2)),
+                                         (Lagrange{2, Square, 1}(), JuAFEM.get_gaussrule(2, Square(), 2)),
+                                         (Lagrange{2, Triangle, 1}(), JuAFEM.get_gaussrule(2, Triangle(), 2)),
+                                         (Lagrange{2, Triangle, 2}(), JuAFEM.get_gaussrule(2, Triangle(), 2)),
+                                         (Lagrange{3, Square, 1}(), JuAFEM.get_gaussrule(3, Square(), 2)),
+                                         (Serendipity{2, Square, 2}(), JuAFEM.get_gaussrule(2, Square(), 2)))
 
 
         fev = FEValues(quad_rule, function_space)

--- a/test/test_fevalues.jl
+++ b/test/test_fevalues.jl
@@ -43,8 +43,8 @@ import JuAFEM: Square, Triangle
     D = hooke(2, 200e9, 0.3)
     t = 2.0
 
-    function_space = JuAFEM.Lagrange{2, JuAFEM.Square, 1}()
-    q_rule = JuAFEM.get_gaussrule(Dim{2}, Square(), 2)
+    function_space = Lagrange{2, JuAFEM.Square, 1}()
+    q_rule = get_gaussrule(Dim{2}, Square(), 2)
     fev = FEValues(Float64, q_rule, function_space)
 
 
@@ -78,13 +78,13 @@ end
 
 @testset "function interpolations" begin
 
-    for (function_space, quad_rule) in  ((Lagrange{1, Square, 1}(), JuAFEM.get_gaussrule(Dim{1}, Square(), 2)),
-                                         (Lagrange{1, Square, 2}(), JuAFEM.get_gaussrule(Dim{1}, Square(), 2)),
-                                         (Lagrange{2, Square, 1}(), JuAFEM.get_gaussrule(Dim{2}, Square(), 2)),
-                                         (Lagrange{2, Triangle, 1}(), JuAFEM.get_gaussrule(Dim{2}, Triangle(), 2)),
-                                         (Lagrange{2, Triangle, 2}(), JuAFEM.get_gaussrule(Dim{2}, Triangle(), 2)),
-                                         (Lagrange{3, Square, 1}(), JuAFEM.get_gaussrule(Dim{3}, Square(), 2)),
-                                         (Serendipity{2, Square, 2}(), JuAFEM.get_gaussrule(Dim{2}, Square(), 2)))
+    for (function_space, quad_rule) in  ((Lagrange{1, Square, 1}(), get_gaussrule(Dim{1}, Square(), 2)),
+                                         (Lagrange{1, Square, 2}(), get_gaussrule(Dim{1}, Square(), 2)),
+                                         (Lagrange{2, Square, 1}(), get_gaussrule(Dim{2}, Square(), 2)),
+                                         (Lagrange{2, Triangle, 1}(), get_gaussrule(Dim{2}, Triangle(), 2)),
+                                         (Lagrange{2, Triangle, 2}(), get_gaussrule(Dim{2}, Triangle(), 2)),
+                                         (Lagrange{3, Square, 1}(), get_gaussrule(Dim{3}, Square(), 2)),
+                                         (Serendipity{2, Square, 2}(), get_gaussrule(Dim{2}, Square(), 2)))
 
 
         fev = FEValues(quad_rule, function_space)

--- a/test/test_fevalues.jl
+++ b/test/test_fevalues.jl
@@ -44,7 +44,7 @@ import JuAFEM: Square, Triangle
     t = 2.0
 
     function_space = JuAFEM.Lagrange{2, JuAFEM.Square, 1}()
-    q_rule = JuAFEM.get_gaussrule(2, Square(), 2)
+    q_rule = JuAFEM.get_gaussrule(Dim{2}, Square(), 2)
     fev = FEValues(Float64, q_rule, function_space)
 
 
@@ -78,13 +78,13 @@ end
 
 @testset "function interpolations" begin
 
-    for (function_space, quad_rule) in  ((Lagrange{1, Square, 1}(), JuAFEM.get_gaussrule(1, Square(), 2)),
-                                         (Lagrange{1, Square, 2}(), JuAFEM.get_gaussrule(1, Square(), 2)),
-                                         (Lagrange{2, Square, 1}(), JuAFEM.get_gaussrule(2, Square(), 2)),
-                                         (Lagrange{2, Triangle, 1}(), JuAFEM.get_gaussrule(2, Triangle(), 2)),
-                                         (Lagrange{2, Triangle, 2}(), JuAFEM.get_gaussrule(2, Triangle(), 2)),
-                                         (Lagrange{3, Square, 1}(), JuAFEM.get_gaussrule(3, Square(), 2)),
-                                         (Serendipity{2, Square, 2}(), JuAFEM.get_gaussrule(2, Square(), 2)))
+    for (function_space, quad_rule) in  ((Lagrange{1, Square, 1}(), JuAFEM.get_gaussrule(Dim{1}, Square(), 2)),
+                                         (Lagrange{1, Square, 2}(), JuAFEM.get_gaussrule(Dim{1}, Square(), 2)),
+                                         (Lagrange{2, Square, 1}(), JuAFEM.get_gaussrule(Dim{2}, Square(), 2)),
+                                         (Lagrange{2, Triangle, 1}(), JuAFEM.get_gaussrule(Dim{2}, Triangle(), 2)),
+                                         (Lagrange{2, Triangle, 2}(), JuAFEM.get_gaussrule(Dim{2}, Triangle(), 2)),
+                                         (Lagrange{3, Square, 1}(), JuAFEM.get_gaussrule(Dim{3}, Square(), 2)),
+                                         (Serendipity{2, Square, 2}(), JuAFEM.get_gaussrule(Dim{2}, Square(), 2)))
 
 
         fev = FEValues(quad_rule, function_space)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -1,5 +1,5 @@
 import JuAFEM: det_spec, inv_spec, inv_spec!,
-               Line, Square, Triangle, Cube, Serendipity, Lagrange
+               Square, Triangle
 
 using ForwardDiff
 
@@ -162,13 +162,13 @@ end
 
 @testset "function space derivatives and sums" begin
 
-    for functionspace in (Lagrange{1, Line}(),
-                          Lagrange{2, Line}(),
-                          Lagrange{1, Square}(),
-                          Lagrange{1, Triangle}(),
-                          Lagrange{2, Triangle}(),
-                          Lagrange{1, Cube}(),
-                          Serendipity{2, Square}())
+    for functionspace in (Lagrange{1, Square, 1}(),
+                          Lagrange{2, Square, 1}(),
+                          Lagrange{1, Square, 2}(),
+                          Lagrange{1, Triangle, 2}(),
+                          Lagrange{2, Triangle, 2}(),
+                          Lagrange{1, Square, 3}(),
+                          Serendipity{2, Square, 2}())
         x = rand(JuAFEM.n_dim(functionspace))
         f = (x) -> JuAFEM.value(functionspace, x)
         @test ForwardDiff.jacobian(f, x)' ≈ JuAFEM.derivative(functionspace, x)

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -163,11 +163,11 @@ end
 @testset "function space derivatives and sums" begin
 
     for functionspace in (Lagrange{1, Square, 1}(),
-                          Lagrange{2, Square, 1}(),
                           Lagrange{1, Square, 2}(),
-                          Lagrange{1, Triangle, 2}(),
+                          Lagrange{2, Square, 1}(),
+                          Lagrange{2, Triangle, 1}(),
                           Lagrange{2, Triangle, 2}(),
-                          Lagrange{1, Square, 3}(),
+                          Lagrange{3, Square, 1}(),
                           Serendipity{2, Square, 2}())
         x = rand(JuAFEM.n_dim(functionspace))
         f = (x) -> JuAFEM.value(functionspace, x)


### PR DESCRIPTION
This continues the work to basically write the same code and only change a dim parameter to run it in different dimensions.

- FunctionSpace is now parameterized on dim.
- Line, Cube are now replaced with simply Square.
- Function spaces needs to be given dimension in order to be created., ie `FunctionSpace{dim, shape, order}`.
- Quadrature rules needs to be given dimension in order to be created, ie `make_quadule(dim, shape, order)`.

See modified tests for how to update code.

To fix:

- [x] Make order of "order" and "dim" consistent.
- [x] Fix comments in function space