### PR TITLE
Faster version of vtk_grid

### DIFF
--- a/src/utilities/VTK.jl
+++ b/src/utilities/VTK.jl
@@ -35,4 +35,38 @@ function vtk_grid(Edof, Coord, Dof, nen, filename::AbstractString)
     return vtk
 end
 
+"""
+    vtk_grid(top, Coord, filename::AbstractString) -> vtkgrid
+Creates an unstructured VTK grid. `nen` is the number of nodes per element
 
+Faster version, can be used if the topology is known, i.e. the nodes for each element
+"""
+function vtk_grid(top, Coord, filename::AbstractString)
+
+    nele = size(top, 2)
+    nen = size(top,1)
+    nnodes = size(Coord, 2)
+    ndim = size(Coord, 1)
+
+    # TODO: This is a bad way of figuring out the eltype
+    if nen == 3 && ndim == 2
+        cell =  VTKCellType.VTK_TRIANGLE
+    elseif nen == 4 && ndim == 2
+        cell = VTKCellType.VTK_QUAD
+    elseif nen == 4 && ndim == 2
+        cell = VTKCellType.VTK_HEXAHEDRON
+    end
+
+    points = Coord
+
+    if ndim == 2
+        points = [points; zeros(nnodes)']
+    elseif ndim == 1
+        points = [points; zeros(nnodes)'; zeros(nnodes)']
+    end
+
+    cells = MeshCell[MeshCell(cell, top[:,i]) for i = 1:nele]
+
+    vtk = vtk_grid(filename, points, cells)
+    return vtk
+end

--- a/src/utilities/VTK.jl
+++ b/src/utilities/VTK.jl
@@ -36,15 +36,15 @@ function vtk_grid(Edof, Coord, Dof, nen, filename::AbstractString)
 end
 
 """
-    vtk_grid(top, Coord, filename::AbstractString) -> vtkgrid
+    vtk_grid(topology, Coord, filename::AbstractString) -> vtkgrid
 Creates an unstructured VTK grid. `nen` is the number of nodes per element
 
 Faster version, can be used if the topology is known, i.e. the nodes for each element
 """
-function vtk_grid(top, Coord, filename::AbstractString)
+function vtk_grid(topology::Matrix{Int}, Coord, filename::AbstractString)
 
-    nele = size(top, 2)
-    nen = size(top,1)
+    nele = size(topology, 2)
+    nen = size(topology,1)
     nnodes = size(Coord, 2)
     ndim = size(Coord, 1)
 
@@ -65,7 +65,7 @@ function vtk_grid(top, Coord, filename::AbstractString)
         points = [points; zeros(nnodes)'; zeros(nnodes)']
     end
 
-    cells = MeshCell[MeshCell(cell, top[:,i]) for i = 1:nele]
+    cells = MeshCell[MeshCell(cell, topology[:,i]) for i = 1:nele]
 
     vtk = vtk_grid(filename, points, cells)
     return vtk

--- a/src/utilities/VTK.jl
+++ b/src/utilities/VTK.jl
@@ -36,7 +36,7 @@ function vtk_grid(Edof, Coord, Dof, nen, filename::AbstractString)
 end
 
 """
-    vtk_grid(topology, Coord, filename::AbstractString) -> vtkgrid
+    vtk_grid(topology::Matrix{Int}, Coord, filename::AbstractString) -> vtkgrid
 Creates an unstructured VTK grid. `nen` is the number of nodes per element
 
 Faster version, can be used if the topology is known, i.e. the nodes for each element


### PR DESCRIPTION
Added a faster version of `vtk_grid` which can be used if the topology is known (which is quite common)

Test with a mesh with 100x100 elements:
```jl
julia> @time vtk_grid(edof, Coord, Dof, 4, "vtk_outfile")
  1.652264 seconds (334.70 k allocations: 12.642 MB)

julia> @time vtk_grid(top, Coord, "vtk_outfile")
  0.034052 seconds (79.24 k allocations: 4.011 MB)
```

200x200 elements:
```jl
julia> @time vtk_grid(edof, Coord, Dof, 4, "vtk_outfile")
 25.855713 seconds (1.35 M allocations: 50.621 MB, 0.05% gc time)

julia> @time vtk_grid(top, Coord, "vtk_outfile")
  0.153537 seconds (319.34 k allocations: 15.901 MB)
```


1000x1000 elements (this definitely crashes with the original version):
```jl
julia> @time vtk_grid(top, Coord, "vtk_outfile")
  4.168526 seconds (8.00 M allocations: 376.221 MB, 11.23% gc time)
```

