### PR TITLE
change quadrature construction (again)

### DIFF
--- a/examples/Yeoh_large_deformations.ipynb
+++ b/examples/Yeoh_large_deformations.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -32,22 +32,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "get_material (generic function with 1 method)"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "immutable YeohMaterial{T}\n",
     "    λ::T\n",
@@ -84,22 +73,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "intf_element (generic function with 1 method)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Takes the initial + current configuration, the fe_value object and the material parameters and\n",
     "# computes the internal forces for the element.\n",
@@ -123,7 +101,7 @@
     "    for q_point in 1:length(JuAFEM.points(get_quadrule(fe_values)))\n",
     "        F = function_vector_gradient(fe_values, q_point, x_vec)\n",
     "        C = F' ⋅ F\n",
-    "        S = Tensor{2, 2}(S_Yeoh(C))\n",
+    "        S = Tensor{2, 2}(S_Yeoh(vec(C)))\n",
     "        P = F ⋅ S\n",
     "        for i in 1:n_basefuncs\n",
     "            fe[i] += P ⋅ shape_gradient(fe_values, q_point, i) * detJdV(fe_values, q_point)\n",
@@ -143,22 +121,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "read_data (generic function with 1 method)"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "immutable CALMesh2D\n",
     "    coord::Matrix{Float64}\n",
@@ -192,23 +159,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "internal_forces! (generic function with 1 method)"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Assembles the global internal forces as well as the reaction forces\n",
     "# for the prescribed dofs\n",
@@ -222,7 +178,7 @@
     "        f_full[dofs] += fe\n",
     "    end\n",
     "    f_react[dof_fixed] = f_full[dof_fixed]\n",
-    "    fvec[:] = f_full[dof_free]\n",
+    "    copy!(fvec, f_full[dof_free])\n",
     "end"
    ]
   },
@@ -235,22 +191,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "grad! (generic function with 1 method)"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "function grad!(fvec, X, x, mesh, material_parameters, dof_free, fe_values)\n",
     "    n_basefuncs = n_basefunctions(get_functionspace(fe_values))\n",
@@ -280,22 +225,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "vtkoutput (generic function with 1 method)"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "function vtkoutput(pvd, i, mesh, X, x, topology, f_react)\n",
     "    u = x - X\n",
@@ -326,22 +260,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "go (generic function with 1 method)"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "function go()\n",
     "    # Get the data\n",
@@ -354,7 +277,7 @@
     "    pvd = paraview_collection(\"box\")\n",
     "    \n",
     "    function_space = Lagrange{2, RefTetrahedron, 1}()\n",
-    "    quad_rule = GaussQuadrature(Dim{2}, RefTetrahedron(), 1)\n",
+    "    quad_rule = QuadratureRule(Dim{2}, RefTetrahedron(), 1)\n",
     "    fe_values = FEValues(Float64, quad_rule, function_space)\n",
     "    \n",
     "    # Initialize\n",
@@ -388,7 +311,7 @@
     "\n",
     "        println(\"Timestep $i out of $nsteps\")\n",
     "        df = DifferentiableSparseMultivariateFunction(f!, g!)\n",
-    "        res = nlsolve(df, dx0; ftol = 1e-6, iterations = 20, method=:newton)\n",
+    "        res = nlsolve(df, dx0; ftol = 1e-6, iterations = 20, method=:newton, show_trace=true)\n",
     "        if !converged(res)\n",
     "            error(\"Global equation did not converge\")\n",
     "        end\n",
@@ -398,47 +321,20 @@
     "        vtkoutput(pvd, i, mesh, X, x, topology, f_react)\n",
     "    end\n",
     "    vtk_save(pvd)\n",
-    "    return X, x\n",
+    "    return\n",
     "end"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Timestep 1 out of 20\n",
-      "Timestep 2 out of 20\n",
-      "Timestep 3 out of 20\n",
-      "Timestep 4 out of 20\n",
-      "Timestep 5 out of 20\n",
-      "Timestep 6 out of 20\n",
-      "Timestep 7 out of 20\n",
-      "Timestep 8 out of 20\n",
-      "Timestep 9 out of 20\n",
-      "Timestep 10 out of 20\n",
-      "Timestep 11 out of 20\n",
-      "Timestep 12 out of 20\n",
-      "Timestep 13 out of 20\n",
-      "Timestep 14 out of 20\n",
-      "Timestep 15 out of 20\n",
-      "Timestep 16 out of 20\n",
-      "Timestep 17 out of 20\n",
-      "Timestep 18 out of 20\n",
-      "Timestep 19 out of 20\n",
-      "Timestep 20 out of 20\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "go();"
+    "go()"
    ]
   }
  ],

--- a/examples/stiffness_example.ipynb
+++ b/examples/stiffness_example.ipynb
@@ -9,14 +9,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "using JuAFEM\n",
-    "using Devectorize"
+    "using JuAFEM"
    ]
   },
   {
@@ -44,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false,
     "scrolled": true
@@ -52,7 +51,7 @@
    "outputs": [],
    "source": [
     "function_space = Lagrange{2, JuAFEM.RefCube, 1}()\n",
-    "quad_rule = GaussQuadrature(Dim{2}, JuAFEM.RefCube(), 2)\n",
+    "quad_rule = QuadratureRule(Dim{2}, JuAFEM.RefCube(), 2)\n",
     "fe_values = FEValues(Float64, quad_rule, function_space);\n",
     "\n",
     "x = [0. 1 1 0;\n",
@@ -69,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -80,7 +79,7 @@
        "ke_element_mat! (generic function with 1 method)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -119,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -130,7 +129,7 @@
        "ke_element! (generic function with 1 method)"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -159,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -170,24 +169,6 @@
      "text": [
       "  "
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "8x8 Array{Float64,2}:\n",
-       "  0.732447    0.729767   -0.134838   …  -0.534914   -0.0364283  -0.132157 \n",
-       "  0.634895    0.632506   -0.157508      -0.432336   -0.0623614  -0.155119 \n",
-       " -0.126301   -0.318895   -0.0473833      0.124042    0.218649    0.14521  \n",
-       " -0.19112     0.0214643   0.244582      -0.221634   -0.024713    0.031998 \n",
-       " -0.561181   -0.534914   -0.0364283      0.729767   -0.134838   -0.0626947\n",
-       " -0.415026   -0.432336   -0.0623614  …   0.632506   -0.157508   -0.0450506\n",
-       " -0.0449647   0.124042    0.218649      -0.318895   -0.0473833   0.0496421\n",
-       " -0.0287493  -0.221634   -0.024713       0.0214643   0.244582    0.168171 "
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -202,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -211,17 +192,17 @@
      "data": {
       "text/plain": [
        "8x8 Array{Float64,2}:\n",
-       "  0.732447    0.729767   -0.134838   …  -0.534914   -0.0364283  -0.132157 \n",
-       "  0.634895    0.632506   -0.157508      -0.432336   -0.0623614  -0.155119 \n",
-       " -0.126301   -0.318895   -0.0473833      0.124042    0.218649    0.14521  \n",
-       " -0.19112     0.0214643   0.244582      -0.221634   -0.024713    0.031998 \n",
-       " -0.561181   -0.534914   -0.0364283      0.729767   -0.134838   -0.0626947\n",
-       " -0.415026   -0.432336   -0.0623614  …   0.632506   -0.157508   -0.0450506\n",
-       " -0.0449647   0.124042    0.218649      -0.318895   -0.0473833   0.0496421\n",
-       " -0.0287493  -0.221634   -0.024713       0.0214643   0.244582    0.168171 "
+       "  0.605694     0.341619   -0.216991    …  -0.303402    0.00487851   0.0470835\n",
+       "  0.723057     0.518509    0.095869       -0.395473   -0.360256     0.300418 \n",
+       "  0.00999195   0.0257821   0.242757       -0.0639996  -0.0306442    0.226967 \n",
+       " -0.157015     0.0280719   0.33449        -0.151107   -0.0701033    0.149403 \n",
+       " -0.393581    -0.303402    0.00487851      0.341619   -0.216991    -0.085301 \n",
+       " -0.45867     -0.395473   -0.360256    …   0.518509    0.095869    -0.423453 \n",
+       " -0.222105    -0.0639996  -0.0306442       0.0257821   0.242757    -0.188749 \n",
+       " -0.107371    -0.151107   -0.0701033       0.0280719   0.33449     -0.0263676"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -237,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -245,10 +226,10 @@
     {
      "data": {
       "text/plain": [
-       "1.2191531139327896e-16"
+       "9.149011931207741e-17"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/src/JuAFEM.jl
+++ b/src/JuAFEM.jl
@@ -21,12 +21,12 @@ export n_dim, n_basefunctions
 export Lagrange, Serendipity, RefTetrahedron, RefCube
 export QuadratureRule, Dim, weights, points
 
-abstract Shape
+abstract RefShape
 
 immutable Dim{T} end
 
-immutable RefTetrahedron <: Shape end
-immutable RefCube <: Shape end
+immutable RefTetrahedron <: RefShape end
+immutable RefCube <: RefShape end
 
 include("function_spaces.jl")
 include("quadrature.jl")

--- a/src/JuAFEM.jl
+++ b/src/JuAFEM.jl
@@ -19,7 +19,7 @@ export FEValues, reinit!, shape_value, shape_gradient, shape_divergence, detJdV,
                  function_vector_gradient, function_vector_divergence, function_vector_symmetric_gradient
 export n_dim, n_basefunctions
 export Lagrange, Serendipity, RefTetrahedron, RefCube
-export QuadratureRule, GaussQuadrature, Dim, weights, points
+export QuadratureRule, Dim, weights, points
 
 abstract Shape
 

--- a/src/quadrature.jl
+++ b/src/quadrature.jl
@@ -16,7 +16,7 @@ points(qr::QuadratureRule) = qr.points
 
 # Generate Gauss quadrature rules on cubes by doing an outer product
 # over all dimensions
-QuadratureRule{dim}(::Type{Dim{dim}}, shape::Shape, order::Int) = QuadratureRule(:legendre, Dim{dim}, shape, order)
+QuadratureRule{dim}(::Type{Dim{dim}}, shape::RefShape, order::Int) = QuadratureRule(:legendre, Dim{dim}, shape, order)
 
 for dim in (1,2,3)
     @eval begin

--- a/src/quadrature_tables/gaussquad_tet_table.jl
+++ b/src/quadrature_tables/gaussquad_tet_table.jl
@@ -24,7 +24,7 @@ function _get_gauss_tetdata(n::Int)
               b2 b2 a2 w2
               b2 b2 b2 w2]
     else
-        throw(ArgumentError("Unsupported tetraheder gauss integration"))
+        throw(ArgumentError("unsupported order for tetraheder gauss-legendre integration"))
     end
     return xw
 end

--- a/src/quadrature_tables/gaussquad_tri_table.jl
+++ b/src/quadrature_tables/gaussquad_tri_table.jl
@@ -73,7 +73,7 @@ function _get_gauss_tridata(n::Int)
     0.26311282963464 0.00839477740996 0.02723031417443 / 2.0
     0.00839477740996 0.72849239295540 0.02723031417443 / 2.0];
     else
-        throw(ArgumentError("Unsupported triangle gauss integration"))
+        throw(ArgumentError("unsupported order for triangle gauss-legendre integration"))
     end
     return xw
 end

--- a/test/test_fevalues.jl
+++ b/test/test_fevalues.jl
@@ -39,14 +39,14 @@ end
 @testset "function interpolations" begin
 
 
-    for (function_space, quad_rule) in  ((Lagrange{1, RefCube, 1}(), GaussQuadrature(Dim{1}, RefCube(), 2)),
-                                         (Lagrange{1, RefCube, 2}(), GaussQuadrature(Dim{1}, RefCube(), 2)),
-                                         (Lagrange{2, RefCube, 1}(), GaussQuadrature(Dim{2}, RefCube(), 2)),
-                                         (Lagrange{2, RefTetrahedron, 1}(), GaussQuadrature(Dim{2}, RefTetrahedron(), 2)),
-                                         (Lagrange{2, RefTetrahedron, 2}(), GaussQuadrature(Dim{2}, RefTetrahedron(), 2)),
-                                         (Lagrange{3, RefCube, 1}(), GaussQuadrature(Dim{3}, RefCube(), 2)),
-                                         (Serendipity{2, RefCube, 2}(), GaussQuadrature(Dim{2}, RefCube(), 2)),
-                                         (Lagrange{3, RefTetrahedron, 1}(), GaussQuadrature(Dim{3}, RefTetrahedron(), 2)))
+    for (function_space, quad_rule) in  ((Lagrange{1, RefCube, 1}(), QuadratureRule(Dim{1}, RefCube(), 2)),
+                                         (Lagrange{1, RefCube, 2}(), QuadratureRule(Dim{1}, RefCube(), 2)),
+                                         (Lagrange{2, RefCube, 1}(), QuadratureRule(Dim{2}, RefCube(), 2)),
+                                         (Lagrange{2, RefTetrahedron, 1}(), QuadratureRule(Dim{2}, RefTetrahedron(), 2)),
+                                         (Lagrange{2, RefTetrahedron, 2}(), QuadratureRule(Dim{2}, RefTetrahedron(), 2)),
+                                         (Lagrange{3, RefCube, 1}(), QuadratureRule(Dim{3}, RefCube(), 2)),
+                                         (Serendipity{2, RefCube, 2}(), QuadratureRule(Dim{2}, RefCube(), 2)),
+                                         (Lagrange{3, RefTetrahedron, 1}(), QuadratureRule(Dim{3}, RefTetrahedron(), 2)))
 
         fev = FEValues(quad_rule, function_space)
         ndim = n_dim(function_space)

--- a/test/test_quadrules.jl
+++ b/test/test_quadrules.jl
@@ -15,7 +15,7 @@
     for dim = (1,2,3)
         for order in (1,2,3,4)
             f = (x, p) -> sum([x[i]^p for i in 1:length(x)])
-            qr = GaussQuadrature(Dim{dim}, RefCube(), order)
+            qr = QuadratureRule(:legendre, Dim{dim}, RefCube(), order)
             @test integrate(qr, (x) -> f(x, 2*order-1)) < 1e-14
             @test sum(qr.weights) ≈ ref_square_vol(dim)
         end
@@ -25,7 +25,7 @@
     g = (x) -> sqrt(sum(x))
     dim = 2
     for order in (2, 3)
-        qr = GaussQuadrature(Dim{dim}, RefTetrahedron(), order)
+        qr = QuadratureRule(:legendre, Dim{dim}, RefTetrahedron(), order)
         # http://www.wolframalpha.com/input/?i=integrate+sqrt(x%2By)+from+x+%3D+0+to+1,+y+%3D+0+to+1-x
         @test integrate(qr, g) - 0.4 < 0.01
         @test sum(qr.weights) ≈ ref_tet_vol(dim)
@@ -33,7 +33,7 @@
 
     dim = 3
     for order in (2, 3)
-        qr = GaussQuadrature(Dim{dim}, RefTetrahedron(), order)
+        qr = QuadratureRule(:legendre, Dim{dim}, RefTetrahedron(), order)
         # Table 1:
         # http://www.m-hikari.com/ijma/ijma-2011/ijma-1-4-2011/venkateshIJMA1-4-2011.pdf
         @test integrate(qr, g) - 0.14 < 0.01


### PR DESCRIPTION
Quadratures are now created by for example:

`QuadratureRule(:legendre, Dim{2}, RefCube(), 2)`

Lobatto quadrature for cubes are created with 

`QuadratureRule(:lobatto, Dim{2}, RefCube(), 2)`
