### PR TITLE
[WIP] Some convenient accessor functions for FEValues

### DIFF
--- a/src/fe_values.jl
+++ b/src/fe_values.jl
@@ -115,6 +115,19 @@ The quadrature rule for the `FEValues` type.
 get_quadrule(fe_v::FEValues) = fe_v.quad_rule
 
 """
+Number of points for the quadrature rule in the `FEValues` object
+"""
+n_quadpoints(fe_v::FEValues) = length(points(fe_v.quad_rule))
+"""
+Get the points for the quadrature rule in the `FEValues` object
+"""
+points(fe_v::FEValues) = points(fe_v.quad_rule)
+"""
+Get the weights for the quadrature rule in the `FEValues` object
+"""
+weights(fe_v::FEValues) = weights(fe_v.quad_rule)
+
+"""
 The function space for the `FEValues` type.
 
 **Arguments**

--- a/test/test_assemble.jl
+++ b/test/test_assemble.jl
@@ -1,4 +1,4 @@
-@testset "fevalues" begin
+@testset "assemble" begin
     a = start_assemble()
     dofs = [1, 3, 5, 7]
     Ke = rand(4, 4)


### PR DESCRIPTION
Now we can write:

``` jl
for q_point in 1:n_quadpoints(fe_values)
    ....
end
```

instead of 

``` jl
for q_point in 1:length(points(get_quadrule(fe_values)))
    ...
end
```

in the element function.
