### PR TITLE
New version of vtk_grid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.4
 FastGaussQuadrature
 Requires
-WriteVTK
+WriteVTK 0.4.0
 Reexport
 ContMechTensors

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 FastGaussQuadrature
 Requires
 WriteVTK 0.4.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ environment:
   matrix:
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
 
 branches:
   only:

--- a/src/VTK.jl
+++ b/src/VTK.jl
@@ -1,5 +1,10 @@
-function get_cell_type(nen, ndim)
-    # TODO: This is a bad way of figuring out the eltype
+# Deprecated function
+function vtk_grid{T}(topology::Matrix{Int}, coord::Matrix{T}, filename::AbstractString)
+    Base.depwarn("vtk_grid(topology::Matrix{Int}, coord::Matrix, filename::AbstractString) is deprecated, use vtk_grid{dim,T}(filename::AbstractString, coords::Vector{Vec{dim,T}}, topology::Matrix{Int}, celltype::VTKCellTypes.VTKCellType) instead", :vtk_grid)
+    nen = size(topology,1)
+    nnodes = size(coord, 2)
+    ndim = size(coord, 1)
+
     if nen == 3 && ndim == 2
         cell =  VTKCellTypes.VTK_TRIANGLE
     elseif nen == 4 && ndim == 2
@@ -9,38 +14,10 @@ function get_cell_type(nen, ndim)
     elseif nen == 4 && ndim == 3
         cell = VTKCellTypes.VTK_TETRA
     end
-    return cell
-end
 
-function pad_zeros(points, ndim, nnodes)
-    if ndim == 3
-        points = points
-    elseif ndim == 2
-        points = [points; zeros(nnodes)']
-    elseif ndim == 1
-        points = [points; zeros(nnodes)'; zeros(nnodes)']
-    end
-    return points
-end
+    coords = reinterpret(Vec{ndim,T},coord,(nnodes,))
 
-function vtk_grid(topology::Matrix{Int}, coord::Matrix, filename::AbstractString)
-    Base.depwarn("vtk_grid(topology::Matrix{Int}, coord::Matrix, filename::AbstractString) is deprecated, use vtk_grid{dim,T}(filename::AbstractString, coords::Vector{Vec{dim,T}}, topology::Matrix{Int}, celltype::VTKCellTypes.VTKCellType) instead", :vtk_grid)
-    nele = size(topology, 2)
-    nen = size(topology,1)
-    nnodes = size(coord, 2)
-    ndim = size(coord, 1)
-    if ndim > 3
-        throw(ArgumentError("dimension > 3, maybe you transposed the input coord matrix"))
-    end
-
-    cell = get_cell_type(nen, ndim)
-
-    points = coord
-    points = pad_zeros(points, ndim, nnodes)
-
-    cells = MeshCell[MeshCell(cell, topology[:,i]) for i = 1:nele]
-
-    vtk = vtk_grid(filename, points, cells)
+    vtk = vtk_grid(filename, coords, topology, cell)
     return vtk
 end
 

--- a/src/VTK.jl
+++ b/src/VTK.jl
@@ -91,7 +91,7 @@ julia> vtk_save(vtkobj)
 
 This is a thin wrapper around the `vtk_grid` function from the [`WriteVTK`](https://github.com/jipolanco/WriteVTK.jl) package.
 
-For infromation how to add cell data and point data to the resulting VTK object as well as how to write it to a file see
+For information how to add cell data and point data to the resulting VTK object as well as how to write it to a file see
 [https://github.com/jipolanco/WriteVTK.jl#generating-an-unstructured-vtk-file](https://github.com/jipolanco/WriteVTK.jl#generating-an-unstructured-vtk-file)
 """
 function vtk_grid{dim,T}(filename::AbstractString, coords::Vector{Vec{dim,T}}, topology::Matrix{Int}, celltype::VTKCellTypes.VTKCellType)

--- a/src/VTK.jl
+++ b/src/VTK.jl
@@ -1,13 +1,13 @@
 function get_cell_type(nen, ndim)
     # TODO: This is a bad way of figuring out the eltype
     if nen == 3 && ndim == 2
-        cell =  VTKCellType.VTK_TRIANGLE
+        cell =  VTKCellTypes.VTK_TRIANGLE
     elseif nen == 4 && ndim == 2
-        cell = VTKCellType.VTK_QUAD
+        cell = VTKCellTypes.VTK_QUAD
     elseif nen == 4 && ndim == 2
-        cell = VTKCellType.VTK_HEXAHEDRON
+        cell = VTKCellTypes.VTK_HEXAHEDRON
     elseif nen == 4 && ndim == 3
-        cell = VTKCellType.VTK_TETRA
+        cell = VTKCellTypes.VTK_TETRA
     end
     return cell
 end
@@ -23,53 +23,8 @@ function pad_zeros(points, ndim, nnodes)
     return points
 end
 
-"""
-Creates an unstructured VTK grid from the element topology and coordinates.
-
-
-    vtk_grid(topology::Matrix{Int}, coord::Matrix, filename::AbstractString)
-
-
-**Arguments**
-
-* `topology` A matrix where each column contains the vertices of the element
-* `coord` A matrix of the coordinates, one column per coordinate
-* `filename`: Name of the file when it is saved to disk
-
-**Results:**
-
-* `::DatasetFile`
-
-**Example:**
-
-```julia
-julia> coords = [0.0 0.0; 1.0 0.0; 0.5 1.0; 1.5 1.0]'
-2x4 Array{Float64,2}:
- 0.0  1.0  0.5  1.5
- 0.0  0.0  1.0  1.0
-
-julia> topology = [1 2 3; 2 4 3]'
-3x2 Array{Int64,2}:
- 1  2
- 2  4
- 3  3
-
-julia> vtkobj = vtk_grid(topology, coords, "example");
-
-julia> vtk_save(vtkobj)
-1-element Array{UTF8String,1}:
- "example.vtu"
-```
-
-**Details**
-
-This is a thin wrapper around the `vtk_grid` function from the [`WriteVTK`](https://github.com/jipolanco/WriteVTK.jl) package.
-
-For infromation how to add cell data and point data to the resulting VTK object as well as how to write it to a file see
-[https://github.com/jipolanco/WriteVTK.jl#generating-an-unstructured-vtk-file](https://github.com/jipolanco/WriteVTK.jl#generating-an-unstructured-vtk-file)
-"""
 function vtk_grid(topology::Matrix{Int}, coord::Matrix, filename::AbstractString)
-
+    Base.depwarn("vtk_grid(topology::Matrix{Int}, coord::Matrix, filename::AbstractString) is deprecated, use vtk_grid{dim,T}(filename::AbstractString, coords::Vector{Vec{dim,T}}, topology::Matrix{Int}, celltype::VTKCellTypes.VTKCellType) instead", :vtk_grid)
     nele = size(topology, 2)
     nen = size(topology,1)
     nnodes = size(coord, 2)
@@ -87,4 +42,67 @@ function vtk_grid(topology::Matrix{Int}, coord::Matrix, filename::AbstractString
 
     vtk = vtk_grid(filename, points, cells)
     return vtk
+end
+
+"""
+Creates an unstructured VTK grid from the element topology and coordinates.
+
+
+    vtk_grid{dim,T}(filename::AbstractString, coords::Vector{Vec{dim,T}}, topology::Matrix{Int}, celltype::VTKCellTypes.VTKCellType)
+
+
+**Arguments**
+
+* `filename` Name (or path) of the file when it is saved to disk, eg `filename = "myfile"`, or `filename = "/results/myfile"` to store it in the folder results
+* `coords` A vector of the node coordinates
+* `topology` A matrix where each column contains the nodes which connects the element
+* `celltype` The definition of the celltype in the grid, see [https://github.com/jipolanco/WriteVTK.jl#defining-cells](https://github.com/jipolanco/WriteVTK.jl#defining-cells)
+
+**Results:**
+
+* `::DatasetFile`
+
+**Example:**
+
+```julia
+julia> coords = [Vec{2}((0.0,0.0)), Vec{2}((1.0,0.0)), Vec{2}((1.5,1.5)), Vec{2}((0.0,1.0))]
+4-element Array{ContMechTensors.Tensor{1,2,Float64,2},1}:
+ [0.0,0.0]
+ [1.0,0.0]
+ [1.5,1.5]
+ [0.0,1.0]
+
+julia> topology = [1 2 4; 2 3 4]'
+3×2 Array{Int64,2}:
+ 1  2
+ 2  3
+ 4  4
+
+julia> celltype = VTKCellTypes.VTK_TRIANGLE;
+
+julia> vtkobj = vtk_grid("example", coords, topology, celltype);
+
+julia> vtk_save(vtkobj)
+1-element Array{String,1}:
+ "example.vtu"
+```
+
+**Details**
+
+This is a thin wrapper around the `vtk_grid` function from the [`WriteVTK`](https://github.com/jipolanco/WriteVTK.jl) package.
+
+For infromation how to add cell data and point data to the resulting VTK object as well as how to write it to a file see
+[https://github.com/jipolanco/WriteVTK.jl#generating-an-unstructured-vtk-file](https://github.com/jipolanco/WriteVTK.jl#generating-an-unstructured-vtk-file)
+"""
+function vtk_grid{dim,T}(filename::AbstractString, coords::Vector{Vec{dim,T}}, topology::Matrix{Int}, celltype::VTKCellTypes.VTKCellType)
+
+    Nel = size(topology,2)
+    Npts = length(coords)
+    coords = reinterpret(T,coords,(dim,Npts))
+    cells = MeshCell[]
+    for el in 1:Nel
+        push!(cells, MeshCell(celltype, topology[:,el]))
+    end
+
+    return vtk_grid(filename,coords,cells)
 end

--- a/src/VTK.jl
+++ b/src/VTK.jl
@@ -73,11 +73,11 @@ For information how to add cell data and point data to the resulting VTK object 
 """
 function vtk_grid{dim,T}(filename::AbstractString, coords::Vector{Vec{dim,T}}, topology::Matrix{Int}, celltype::VTKCellTypes.VTKCellType)
 
-    Nel = size(topology,2)
-    Npts = length(coords)
-    coords = reinterpret(T,coords,(dim,Npts))
+    nel = size(topology,2)
+    npts = length(coords)
+    coords = reinterpret(T,coords,(dim,npts))
     cells = MeshCell[]
-    for el in 1:Nel
+    for el in 1:nel
         push!(cells, MeshCell(celltype, topology[:,el]))
     end
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 BaseTestNext
 ForwardDiff
+SHA

--- a/test/checksums.sha1
+++ b/test/checksums.sha1
@@ -1,0 +1,3 @@
+14d2ef631652e11e2fa2129aa153da1a8c2486da triangles.vtu
+ebebd6de36ea79b28e2c34c093192a786be89970 triangles_old.vtu
+12cbaaf7273644fa0d0685a8424acc37b2a1e818 quads.vtu

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,6 @@
 using JuAFEM
 using FastGaussQuadrature
-
-if VERSION >= v"0.5-"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
+using Base.Test
 
 include("test_fevalues.jl")
 include("test_quadrules.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,3 +11,4 @@ end
 include("test_fevalues.jl")
 include("test_quadrules.jl")
 include("test_assemble.jl")
+include("test_VTK.jl")

--- a/test/test_VTK.jl
+++ b/test/test_VTK.jl
@@ -1,0 +1,81 @@
+using SHA
+@testset "VTK" begin
+    OVERWRITE_CHECKSUMS = false
+    checksums_file = "checksums.sha1"
+    checksum_list = readstring(checksums_file)
+    if OVERWRITE_CHECKSUMS
+        csio = open(checksums_file, "w")
+    end
+
+    # Set up small mesh
+    n1 = Vec{2}((0.0,0.0))
+    n2 = Vec{2}((1.0,0.0))
+    n3 = Vec{2}((2.0,0.0))
+    n4 = Vec{2}((0.0,1.0))
+    n5 = Vec{2}((1.0,1.0))
+    n6 = Vec{2}((2.0,1.0))
+    n7 = Vec{2}((0.0,2.0))
+    n8 = Vec{2}((1.0,2.0))
+    n9 = Vec{2}((2.0,2.0))
+    coords = Vec{2,Float64}[n1,n2,n3,n4,n5,n6,n7,n8,n9]
+
+    #####################
+    # Triangle 2-D mesh #
+    #####################
+    celltype = WriteVTK.VTKCellTypes.VTK_TRIANGLE
+    triangle_mesh_edof = [1 2 4
+                          2 5 4
+                          2 6 5
+                          2 3 6
+                          4 8 7
+                          4 5 8
+                          5 6 8
+                          6 9 8]'
+    vtkfile = vtk_grid("triangles",coords,triangle_mesh_edof,celltype)
+    vtk_save(vtkfile)
+
+    sha = bytes2hex(sha1("triangles.vtu"))
+    if OVERWRITE_CHECKSUMS
+        write(csio, sha*" triangles.vtu\n")
+    else
+        # Returns 0:-1 if string is not found
+        cmp = search(checksum_list, sha)
+        @test cmp != 0:-1
+    end
+
+    # Test old version as well
+    coordmat = reinterpret(Float64,coords,(2,9))
+    vtkfile = vtk_grid(triangle_mesh_edof,coordmat,"triangles_old")
+    vtk_save(vtkfile)
+
+    sha = bytes2hex(sha1("triangles_old.vtu"))
+    if OVERWRITE_CHECKSUMS
+        write(csio, sha*" triangles_old.vtu\n")
+    else
+        # Returns 0:-1 if string is not found
+        cmp = search(checksum_list, sha)
+        @test cmp != 0:-1
+    end
+
+    #################
+    # Quad 2-D mesh #
+    #################
+    celltype = WriteVTK.VTKCellTypes.VTK_QUAD
+    quad_mesh_edof = [1 2 5 4
+                      2 3 6 5
+                      4 5 8 7
+                      5 6 9 8]'
+    vtkfile = vtk_grid("quads",coords,quad_mesh_edof,celltype)
+    vtk_save(vtkfile)
+
+    sha = bytes2hex(sha1("quads.vtu"))
+    if OVERWRITE_CHECKSUMS
+        write(csio, sha*" quads.vtu\n")
+    else
+        # Returns 0:-1 if string is not found
+        cmp = search(checksum_list, sha)
+        @test cmp != 0:-1
+    end
+
+    OVERWRITE_CHECKSUMS && close(csio)
+end


### PR DESCRIPTION
Thinking about removing everything above [this](https://github.com/fredrikekre/JuAFEM.jl/blob/caa497b172708c122b5c5e4f9220db0dd051f480/src/VTK.jl#L47), or should we leave it there? I think its more neat if we use the tensors and specify the celltype explicitly instead of trying to guessing.

~~Will fail until the new `WriteVTK` version is tagged.~~