### PR TITLE
Spatial coordinate

### DIFF
--- a/src/JuAFEM.jl
+++ b/src/JuAFEM.jl
@@ -16,7 +16,7 @@ export start_assemble, assemble, end_assemble
 
 export FECellValues, reinit!, shape_value, shape_gradient, shape_divergence, detJdV, get_quadrule, get_functionspace, get_geometricspace,
                      function_scalar_value, function_vector_value, function_scalar_gradient,
-                     function_vector_gradient, function_vector_divergence, function_vector_symmetric_gradient
+                     function_vector_gradient, function_vector_divergence, function_vector_symmetric_gradient, spatial_coordinate
 export FEBoundaryValues, get_boundarynumber
 export FunctionSpace, functionspace_n_dim, functionspace_ref_shape, functionspace_order, n_basefunctions
 export Lagrange, Serendipity, RefTetrahedron, RefCube

--- a/src/fe_cell_values.jl
+++ b/src/fe_cell_values.jl
@@ -32,6 +32,7 @@ values of nodal functions, gradients and divergences of nodal functions etc. in 
 * [`function_vector_divergence`](@ref)
 * [`function_vector_gradient`](@ref)
 * [`function_vector_symmetric_gradient`](@ref)
+* [`spatial_coordinate`](@ref)
 """
 immutable FECellValues{dim, T <: Real, FS <: FunctionSpace, GS <: FunctionSpace, shape <: AbstractRefShape} <: AbstractFEValues{dim, T, FS, GS}
     N::Vector{Vector{T}}
@@ -40,6 +41,7 @@ immutable FECellValues{dim, T <: Real, FS <: FunctionSpace, GS <: FunctionSpace,
     detJdV::Vector{T}
     quad_rule::QuadratureRule{dim, shape, T}
     function_space::FS
+    M::Vector{Vector{T}}
     dMdξ::Vector{Vector{Vec{dim, T}}}
     geometric_space::GS
 end
@@ -59,17 +61,19 @@ function FECellValues{dim, T, FS <: FunctionSpace, GS <: FunctionSpace, shape <:
 
     # Geometry interpolation
     n_geom_basefuncs = n_basefunctions(geom_space)
+    M = [zeros(T, n_geom_basefuncs) for i in 1:n_qpoints]
     dMdξ = [[zero(Vec{dim, T}) for i in 1:n_geom_basefuncs] for j in 1:n_qpoints]
 
     for (i, ξ) in enumerate(quad_rule.points)
         value!(func_space, N[i], ξ)
         derivative!(func_space, dNdξ[i], ξ)
+        value!(geom_space, M[i], ξ)
         derivative!(geom_space, dMdξ[i], ξ)
     end
 
     detJdV = zeros(T, n_qpoints)
 
-    FECellValues(N, dNdx, dNdξ, detJdV, quad_rule, func_space, dMdξ, geom_space)
+    FECellValues(N, dNdx, dNdξ, detJdV, quad_rule, func_space, M, dMdξ, geom_space)
 end
 
 

--- a/test/test_feboundaryvalues.jl
+++ b/test/test_feboundaryvalues.jl
@@ -62,6 +62,11 @@ for (function_space, quad_rule) in  ((Lagrange{1, RefCube, 1}(), QuadratureRule{
         end
         @test vol ≈ reference_volume(function_space, boundary)
 
+        # Test spatial coordinate (after reinit with ref.coords we should get back the quad_points)
+        for (i, qp_x) in enumerate(points(boundary_quad_rule))
+            @test spatial_coordinate(fe_bv, i, x) ≈ qp_x
+        end
+
     end
 
     # Test boundary number calculation

--- a/test/test_fecellvalues.jl
+++ b/test/test_fecellvalues.jl
@@ -58,6 +58,11 @@ for (function_space, quad_rule) in  ((Lagrange{1, RefCube, 1}(), QuadratureRule{
     end
     @test vol ≈ reference_volume(function_space)
 
+    # Test spatial coordinate (after reinit with ref.coords we should get back the quad_points)
+    for (i, qp_x) in enumerate(points(quad_rule))
+        @test spatial_coordinate(fe_cv, i, x) ≈ qp_x
+    end
+
 end
 
 end # of testset


### PR DESCRIPTION
Support for calculating the spatial coordinate, for both cells and boundaries.

```jl
julia> qr = QuadratureRule{2, RefCube}(2);

julia> fs = Lagrange{2,RefCube,1}();

julia> cell_values = FECellValues(qr,fs);

julia> x = Vec{2, Float64}[Vec{2}((0.0, 0.0)),
                           Vec{2}((1.5, 0.0)),
                           Vec{2}((2.0, 2.0)),
                           Vec{2}((0.0, 1.0))];

julia> reinit!(cell_values, x)

julia> spatial_coordinate(cell_values, 1, x) # spatial coordinate in quad_point 1
2-element ContMechTensors.Tensor{1,2,Float64,2}:
 0.339316
 0.255983
```