### PR TITLE
[RFC] Better way too loop over grid cells

### DIFF
--- a/src/JuAFEM.jl
+++ b/src/JuAFEM.jl
@@ -59,7 +59,7 @@ include("boundary_integrals.jl")
 include("grid.jl")
 include("grid_generators.jl")
 include("VTK.jl")
-include("cell_iterator.jl")
+include("iterators.jl")
 include("deprecations.jl")
 
 end # module

--- a/src/JuAFEM.jl
+++ b/src/JuAFEM.jl
@@ -59,6 +59,7 @@ include("boundary_integrals.jl")
 include("grid.jl")
 include("grid_generators.jl")
 include("VTK.jl")
+include("cell_iterator.jl")
 include("deprecations.jl")
 
 end # module

--- a/src/cell_iterator.jl
+++ b/src/cell_iterator.jl
@@ -12,14 +12,14 @@ end
     # N is number of nodes per cell in the grid
     nodes = zeros(Int, N)
     coords = zeros(Vec{dim, T}, N)
-    return CellIterator(RefValue{Int}(1), nodes, coords)
+    return CellIterator(RefValue{Int}(0), nodes, coords)
 end
 
 @inline function Base.next{dim, N, T}(grid::Grid{dim, N, T}, ci::CellIterator{dim, T})
     # this is a bit awkward, we need to basically reinit the state and also send it out
     # that means that we send out the object twice, but it works I guess.
     # the second output state is only used internally and is hidden from the user
-    ci.cellid[] += 0
+    ci.cellid[] += 1
     nodeids = grid.cells[ci.cellid[]].nodes
     @inbounds for i in 1:N
         nodeid = nodeids[i]
@@ -35,3 +35,5 @@ end
 @inline getid(ci::CellIterator) = ci.cellid[]
 @inline getnodes(ci::CellIterator) = ci.nodes
 @inline getcoordinates(ci::CellIterator) = ci.coords
+
+@inline reinit!{dim, T}(cv::CellValues{dim, T}, ci::CellIterator{dim, T}) = reinit!(cv, ci.coords)

--- a/src/cell_iterator.jl
+++ b/src/cell_iterator.jl
@@ -1,6 +1,4 @@
 
-export CellIterator
-
 immutable CellIterator{dim, T}
     cellid::Ref{Int}
     nodes::Vector{Int}
@@ -22,8 +20,9 @@ function Base.next{dim, N, T}(grid::Grid{dim, N, T}, ci::CellIterator{dim, T})
     id = ci.cellid[]
 
     @inbounds for i in 1:N
-        ci.nodes[i] = grid.cells[id].nodes[i]
-        ci.coords[i] = grid.nodes[grid.cells[id].nodes[i]].x # this could also use getcoordinates! but this is the same
+        nodeid = grid.cells[id].nodes[i]
+        ci.nodes[i] = nodeid
+        ci.coords[i] = grid.nodes[nodeid].x # this could also use getcoordinates! but this is the same
     end
 
     return ci, ci

--- a/src/cell_iterator.jl
+++ b/src/cell_iterator.jl
@@ -1,31 +1,37 @@
+using Base: RefValue
+
+export getid
 
 immutable CellIterator{dim, T}
-    cellid::Ref{Int}
+    cellid::RefValue{Int}
     nodes::Vector{Int}
     coords::Vector{Vec{dim, T}}
 end
 
-function Base.start{dim, N, T}(grid::Grid{dim, N, T})
+@inline function Base.start{dim, N, T}(grid::Grid{dim, N, T})
     # N is number of nodes per cell in the grid
     nodes = zeros(Int, N)
     coords = zeros(Vec{dim, T}, N)
-    return CellIterator(Ref(0), nodes, coords)
+    return CellIterator(RefValue{Int}(1), nodes, coords)
 end
 
-function Base.next{dim, N, T}(grid::Grid{dim, N, T}, ci::CellIterator{dim, T})
+@inline function Base.next{dim, N, T}(grid::Grid{dim, N, T}, ci::CellIterator{dim, T})
     # this is a bit awkward, we need to basically reinit the state and also send it out
     # that means that we send out the object twice, but it works I guess.
     # the second output state is only used internally and is hidden from the user
-    ci.cellid[] += 1
-    id = ci.cellid[]
-
+    ci.cellid[] += 0
+    nodeids = grid.cells[ci.cellid[]].nodes
     @inbounds for i in 1:N
-        nodeid = grid.cells[id].nodes[i]
+        nodeid = nodeids[i]
         ci.nodes[i] = nodeid
-        ci.coords[i] = grid.nodes[nodeid].x # this could also use getcoordinates! but this is the same
+        ci.coords[i] = grid.nodes[nodeid].x
     end
 
-    return ci, ci
+    return ci, ci # the fact that we return ci twice here is allocating memory?!
 end
 
-Base.done{dim, N, T}(grid::Grid{dim, N, T}, ci::CellIterator{dim, T}) = ci.cellid[] >= getncells(grid)
+@inline Base.done{dim, N, T}(grid::Grid{dim, N, T}, ci::CellIterator{dim, T}) = ci.cellid[] >= getncells(grid)
+
+@inline getid(ci::CellIterator) = ci.cellid[]
+@inline getnodes(ci::CellIterator) = ci.nodes
+@inline getcoordinates(ci::CellIterator) = ci.coords

--- a/src/cell_iterator.jl
+++ b/src/cell_iterator.jl
@@ -1,0 +1,32 @@
+
+export CellIterator
+
+immutable CellIterator{dim, T}
+    cellid::Ref{Int}
+    nodes::Vector{Int}
+    coords::Vector{Vec{dim, T}}
+end
+
+function Base.start{dim, N, T}(grid::Grid{dim, N, T})
+    # N is number of nodes per cell in the grid
+    nodes = zeros(Int, N)
+    coords = zeros(Vec{dim, T}, N)
+    return CellIterator(Ref(0), nodes, coords)
+end
+
+function Base.next{dim, N, T}(grid::Grid{dim, N, T}, ci::CellIterator{dim, T})
+    # this is a bit awkward, we need to basically reinit the state and also send it out
+    # that means that we send out the object twice, but it works I guess.
+    # the second output state is only used internally and is hidden from the user
+    ci.cellid[] += 1
+    id = ci.cellid[]
+
+    @inbounds for i in 1:N
+        ci.nodes[i] = grid.cells[id].nodes[i]
+        ci.coords[i] = grid.nodes[grid.cells[id].nodes[i]].x # this could also use getcoordinates! but this is the same
+    end
+
+    return ci, ci
+end
+
+Base.done{dim, N, T}(grid::Grid{dim, N, T}, ci::CellIterator{dim, T}) = ci.cellid[] >= getncells(grid)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -1,5 +1,7 @@
-using Base: RefValue
+# this file defines iterators for looping over a grid
 
+
+using Base: RefValue
 export getid
 
 """
@@ -10,22 +12,17 @@ contains information about the cell which can be queried from the object.
 
 ```julia
 for cell in grid                 # cell is now a CellIterator
-
     id = getid(cell)             # get the cell number
     coord = getcoordinates(cell) # get the coordinates
     nodes = getnodes(cell)       # get the node numbers
-
 end
 ```
 The `CellIterator` can also be used directly to [`reinit!`](@ref) the [`CellValues`](@ref):
 
 ```julia
 for cell in grid
-
     reinit!(cv, cell)
-
     # do stuff
-
 end
 ```
 """
@@ -49,12 +46,12 @@ end
         ci.nodes[i] = nodeid
         ci.coords[i] = grid.nodes[nodeid].x
     end
-
     return ci, ci
 end
 
 @inline Base.done{dim, N, T}(grid::Grid{dim, N, T}, ci::CellIterator{dim, T}) = ci.cellid[] >= getncells(grid)
 
+# utility
 @inline getid(ci::CellIterator) = ci.cellid[]
 @inline getnodes(ci::CellIterator) = ci.nodes
 @inline getcoordinates(ci::CellIterator) = ci.coords


### PR DESCRIPTION
First take on a better cell iterator interface.

This only provide a way to loop over the grid, without coupling with `CellValues`.

(keeping it in a separate file until ready to be put in `grid.jl` I guess)