### PR TITLE
[WIP] Add support for evaluating vector functions with vector of node values

### DIFF
--- a/src/common_values.jl
+++ b/src/common_values.jl
@@ -180,6 +180,16 @@ function function_value{dim, T}(fe_v::ScalarValues{dim}, q_point::Int, u::Vector
     return vec
 end
 
+function function_value{dim, T}(fe_v::VectorValues{dim}, q_point::Int, u::Vector{T})
+    n_base_funcs = getnbasefunctions(getfunctioninterpolation(fe_v))*dim
+    @assert length(u) == n_base_funcs
+    vec = zero(Vec{dim, T})
+    @inbounds for i in 1:n_base_funcs
+        vec += shape_value(fe_v, q_point, basefunc) * u[i]
+    end
+    return vec
+end
+
 function function_value{dim, T}(fe_v::VectorValues{dim}, q_point::Int, u::Vector{Vec{dim, T}})
     n_base_funcs = getnbasefunctions(getfunctioninterpolation(fe_v))
     @assert length(u) == n_base_funcs
@@ -236,6 +246,16 @@ function function_gradient{dim, T}(fe_v::ScalarValues{dim}, q_point::Int, u::Vec
     grad = zero(Tensor{2, dim, T})
     @inbounds for i in 1:n_base_funcs
         grad += u[i] ⊗ shape_gradient(fe_v, q_point, i)
+    end
+    return grad
+end
+
+function function_gradient{dim, T}(fe_v::VectorValues{dim}, q_point::Int, u::Vector{T})
+    n_base_funcs = getnbasefunctions(getfunctioninterpolation(fe_v))*dim
+    @assert length(u) == n_base_funcs
+    grad = zero(Tensor{2, dim, T})
+    @inbounds for i in 1:n_base_funcs
+        grad += shape_gradient(fe_v, q_point, i) * u[i]
     end
     return grad
 end
@@ -315,6 +335,19 @@ function function_divergence{dim, T}(fe_v::ScalarValues{dim}, q_point::Int, u::V
     diverg = zero(T)
     @inbounds for i in 1:n_base_funcs
         diverg += shape_gradient(fe_v, q_point, i) ⋅ u[i]
+    end
+    return diverg
+end
+
+function function_divergence{dim, T}(fe_v::VectorValues{dim}, q_point::Int, u::Vector{T})
+    n_base_funcs = getnbasefunctions(getfunctioninterpolation(fe_v))*dim
+    @assert length(u) == n_base_funcs
+    diverg = zero(T)
+    @inbounds for i in 1:n_base_funcs
+        grad = shape_gradient(fe_v, q_point, i)
+        for k in 1:dim
+            diverg += grad[k, k] * u[i]
+        end
     end
     return diverg
 end

--- a/src/common_values.jl
+++ b/src/common_values.jl
@@ -162,7 +162,7 @@ nodal values of ``\\mathbf{u}``.
 """
 function function_value{dim, T}(fe_v::Values{dim}, q_point::Int, u::Vector{T})
     n_base_funcs = getnbasefunctions(getfunctioninterpolation(fe_v))
-    isa(fe_v, VectorValues) && (n_base_funcs *= 3)
+    isa(fe_v, VectorValues) && (n_base_funcs *= dim)
     @assert length(u) == n_base_funcs
     val = zero(_valuetype(fe_v, u))
     @inbounds for i in 1:n_base_funcs
@@ -218,7 +218,7 @@ where ``\\mathbf{u}_i`` are the nodal values of ``\\mathbf{u}``.
 """
 function function_gradient{dim, T}(fe_v::Values{dim}, q_point::Int, u::Vector{T})
     n_base_funcs = getnbasefunctions(getfunctioninterpolation(fe_v))
-    isa(fe_v, VectorValues) && (n_base_funcs *= 3)
+    isa(fe_v, VectorValues) && (n_base_funcs *= dim)
     @assert length(u) == n_base_funcs
     grad = zero(_gradienttype(fe_v, u))
     @inbounds for i in 1:n_base_funcs


### PR DESCRIPTION
First commit implements `function_value`, `function_gradient` and `function_divergence` for the combination of `VectorValues` and `Vector` of nodal values

Second commit combines some of the methods into one. For `function_value` 3 of the 4 methods can be collapsed into one. The last one will have to be a separate I think, due to the additional `dim`-loop.
For `function_gradient` only 2 methods can be collapsed, since `⊗` and `⋅` are used instead of `*` for them.