### PR TITLE
rework celliterator

### DIFF
--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -32,10 +32,15 @@ function CellIterator{dim, N, T}(grid::Grid{dim, N, T})
     return CellIterator(grid, nodes, coords)
 end
 
+# iterator interface
 Base.start(::CellIterator) = 1
 Base.next{dim, N, T}(ci::CellIterator{dim, N, T}, i) = (reinit!(ci, i), i+1)
 Base.done(ci::CellIterator, i) = i > getncells(ci.grid)
 Base.length(ci::CellIterator) = getncells(ci.grid)
+
+Base.iteratorsize{dim, N, T}(::Type{CellIterator{dim, N, T}}) = Base.HasLength()   # this is default in Base
+Base.iteratoreltype{dim, N, T}(::Type{CellIterator{dim, N, T}}) = Base.HasEltype() # this is default in Base
+Base.eltype{dim, N, T}(::Type{CellIterator{dim, N, T}}) = CellIterator{dim, N, T}
 
 # utility
 @inline getnodes(ci::CellIterator) = ci.nodes

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -8,39 +8,43 @@ A `CellIterator` contains information about the cell which can be queried from t
 **Example:**
 
 ```julia
-ci = CellIterator(grid)
-
-for i in 1:getncells(grid)
-    reinit!(grid, ci, i)          # update the CellIterator for cell i
+for cell in CellIterator(grid)
     coords = getcoordinates(cell) # get the coordinates
     nodes = getnodes(cell)        # get the node numbers
 
-    reinit!(cv, ci)               # reinit the FE-base with a CellIterator
+    reinit!(cv, cell)             # reinit! the FE-base with a CellIterator
 end
 ```
 """
-immutable CellIterator{dim, T}
+immutable CellIterator{dim, N, T}
+    grid::Grid{dim, N, T}
     nodes::Vector{Int}
     coords::Vector{Vec{dim, T}}
 end
 
-@inline function CellIterator{dim, N, T}(grid::Grid{dim, N, T})
+function CellIterator{dim, N, T}(grid::Grid{dim, N, T})
     nodes = zeros(Int, N)
     coords = zeros(Vec{dim, T}, N)
-    return CellIterator(nodes, coords)
+    return CellIterator(grid, nodes, coords)
 end
 
-@inline function reinit!{dim, N, T}(ci::CellIterator{dim, T}, grid::Grid{dim, N, T}, i::Int)
-    nodeids = grid.cells[i].nodes
-    @inbounds for i in 1:N
-        nodeid = nodeids[i]
-        ci.nodes[i] = nodeid
-        ci.coords[i] = grid.nodes[nodeid].x
+@inline Base.start(::CellIterator) = 1
+
+@inline function Base.next{dim, N, T}(ci::CellIterator{dim, N, T}, i)
+    nodeids = ci.grid.cells[i].nodes
+    @inbounds for j in 1:N
+        nodeid = nodeids[j]
+        ci.nodes[j] = nodeid
+        ci.coords[j] = ci.grid.nodes[nodeid].x
     end
+    return (ci, i+1)
 end
+
+@inline Base.done(ci::CellIterator, i) = i > getncells(ci.grid)
 
 # utility
 @inline getnodes(ci::CellIterator) = ci.nodes
 @inline getcoordinates(ci::CellIterator) = ci.coords
+@inline reinit!(ci::CellIterator, i::Int) = next(ci, i) # for manual updating
 
-@inline reinit!{dim, T}(cv::CellValues{dim, T}, ci::CellIterator{dim, T}) = reinit!(cv, ci.coords)
+@inline reinit!{dim, N, T}(cv::CellValues{dim, T}, ci::CellIterator{dim, N, T}) = reinit!(cv, ci.coords)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -3,7 +3,11 @@
 export CellIterator
 
 """
-A `CellIterator` contains information about the cell which can be queried from the object.
+```julia
+CellIterator(grid::Grid)
+```
+
+A `CellIterator` is used to conveniently loop over all the cells in a grid.
 
 **Example:**
 
@@ -28,23 +32,22 @@ function CellIterator{dim, N, T}(grid::Grid{dim, N, T})
     return CellIterator(grid, nodes, coords)
 end
 
-@inline Base.start(::CellIterator) = 1
+Base.start(::CellIterator) = 1
+Base.next{dim, N, T}(ci::CellIterator{dim, N, T}, i) = (reinit!(ci, i), i)
+Base.done(ci::CellIterator, i) = i > getncells(ci.grid)
 
-@inline function Base.next{dim, N, T}(ci::CellIterator{dim, N, T}, i)
+# utility
+@inline getnodes(ci::CellIterator) = ci.nodes
+@inline getcoordinates(ci::CellIterator) = ci.coords
+
+function reinit!{dim, N, T}(ci::CellIterator{dim, N, T}, i::Int)
     nodeids = ci.grid.cells[i].nodes
     @inbounds for j in 1:N
         nodeid = nodeids[j]
         ci.nodes[j] = nodeid
         ci.coords[j] = ci.grid.nodes[nodeid].x
     end
-    return (ci, i+1)
+    return ci
 end
-
-@inline Base.done(ci::CellIterator, i) = i > getncells(ci.grid)
-
-# utility
-@inline getnodes(ci::CellIterator) = ci.nodes
-@inline getcoordinates(ci::CellIterator) = ci.coords
-@inline reinit!(ci::CellIterator, i::Int) = next(ci, i) # for manual updating
 
 @inline reinit!{dim, N, T}(cv::CellValues{dim, T}, ci::CellIterator{dim, N, T}) = reinit!(cv, ci.coords)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -33,9 +33,9 @@ function CellIterator{dim, N, T}(grid::Grid{dim, N, T})
 end
 
 Base.start(::CellIterator) = 1
-Base.next{dim, N, T}(ci::CellIterator{dim, N, T}, i) = (reinit!(ci, i), i)
+Base.next{dim, N, T}(ci::CellIterator{dim, N, T}, i) = (reinit!(ci, i), i+1)
 Base.done(ci::CellIterator, i) = i > getncells(ci.grid)
-Base.lenth(ci::CellIterator) = getncells(ci.grid)
+Base.length(ci::CellIterator) = getncells(ci.grid)
 
 # utility
 @inline getnodes(ci::CellIterator) = ci.nodes

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -1,58 +1,45 @@
-# this file defines iterators for looping over a grid
+# this file defines iterators used for looping over a grid
 
-
-using Base: RefValue
-export getid
+export CellIterator
 
 """
-A `CellIterator` is returned when looping over the cells in a grid. The `CellIterator`
-contains information about the cell which can be queried from the object.
+A `CellIterator` contains information about the cell which can be queried from the object.
 
 **Example:**
 
 ```julia
-for cell in grid                 # cell is now a CellIterator
-    id = getid(cell)             # get the cell number
-    coord = getcoordinates(cell) # get the coordinates
-    nodes = getnodes(cell)       # get the node numbers
-end
-```
-The `CellIterator` can also be used directly to [`reinit!`](@ref) the [`CellValues`](@ref):
+ci = CellIterator(grid)
 
-```julia
-for cell in grid
-    reinit!(cv, cell)
-    # do stuff
+for i in 1:getncells(grid)
+    reinit!(grid, ci, i)          # update the CellIterator for cell i
+    coords = getcoordinates(cell) # get the coordinates
+    nodes = getnodes(cell)        # get the node numbers
+
+    reinit!(cv, ci)               # reinit the FE-base with a CellIterator
 end
 ```
 """
 immutable CellIterator{dim, T}
-    cellid::RefValue{Int}
     nodes::Vector{Int}
     coords::Vector{Vec{dim, T}}
 end
 
-@inline function Base.start{dim, N, T}(grid::Grid{dim, N, T})
+@inline function CellIterator{dim, N, T}(grid::Grid{dim, N, T})
     nodes = zeros(Int, N)
     coords = zeros(Vec{dim, T}, N)
-    return CellIterator(RefValue{Int}(0), nodes, coords)
+    return CellIterator(nodes, coords)
 end
 
-@inline function Base.next{dim, N, T}(grid::Grid{dim, N, T}, ci::CellIterator{dim, T})
-    ci.cellid[] += 1
-    nodeids = grid.cells[ci.cellid[]].nodes
+@inline function reinit!{dim, N, T}(ci::CellIterator{dim, T}, grid::Grid{dim, N, T}, i::Int)
+    nodeids = grid.cells[i].nodes
     @inbounds for i in 1:N
         nodeid = nodeids[i]
         ci.nodes[i] = nodeid
         ci.coords[i] = grid.nodes[nodeid].x
     end
-    return ci, ci
 end
 
-@inline Base.done{dim, N, T}(grid::Grid{dim, N, T}, ci::CellIterator{dim, T}) = ci.cellid[] >= getncells(grid)
-
 # utility
-@inline getid(ci::CellIterator) = ci.cellid[]
 @inline getnodes(ci::CellIterator) = ci.nodes
 @inline getcoordinates(ci::CellIterator) = ci.coords
 

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -35,6 +35,7 @@ end
 Base.start(::CellIterator) = 1
 Base.next{dim, N, T}(ci::CellIterator{dim, N, T}, i) = (reinit!(ci, i), i)
 Base.done(ci::CellIterator, i) = i > getncells(ci.grid)
+Base.lenth(ci::CellIterator) = getncells(ci.grid)
 
 # utility
 @inline getnodes(ci::CellIterator) = ci.nodes


### PR DESCRIPTION
This is much cleaner. Usage is now:

```julia
grid = generate_grid(Triangle, (2, 2));

ci = CellIterator(grid);

for i in 1:getncells(grid)
    reinit!(ci, grid, i) # reinit the celliterator
    reinit!(cv, ci)      # reinit the cellvalues via the celliterator
    # do stuff
end
```

Edit: Take 3:
```julia
grid = generate_grid(Triangle, (2, 2));

for cell in CellIterator(grid)
    reinit!(cv, cell)      # reinit the cellvalues via the celliterator
    # do stuff
end
```

it can also be done manually like this:

```julia
grid = generate_grid(Triangle, (2, 2));

ci = CellIterator(grid)

for i in 1:getncells(grid)
    reinit!(ci, i)         # reinit the "iterator"
    reinit!(cv, cell)      # reinit the cellvalues via the celliterator
    # do stuff
end
```
