### PR TITLE
export cellid

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -95,6 +95,7 @@ export
     CellIterator,
     FaceIterator,
     UpdateFlags,
+    cellid,
 
 # assembly
     start_assemble,


### PR DESCRIPTION
Now I can remove 
```julia
@eval JuAFEM begin
    export cellid
end
```
from my code. Kappa.