### PR TITLE
Implement generate_grid(QuadraticTetrahedron, ...)

### DIFF
--- a/src/Grid/grid_generators.jl
+++ b/src/Grid/grid_generators.jl
@@ -429,19 +429,21 @@ function generate_grid(::Type{QuadraticTetrahedron}, cells_per_dim::NTuple{3,Int
     # left = (1, 4, 5, 8), right = (2, 3, 6, 7)
     # front = (1, 2, 5, 6), back = (3, 4, 7, 8)
     # bottom = (1, 2, 3, 4), top = (5, 6, 7, 8)
+
+    localnodes = [  ((1,1,1),(3,1,1),(1,3,1),(1,3,3)),
+                    ((1,1,1),(1,1,3),(3,1,1),(1,3,3)),
+                    ((3,1,1),(3,3,1),(1,3,1),(1,3,3)),
+                    ((3,1,1),(3,3,3),(3,3,1),(1,3,3)),
+                    ((3,1,1),(1,1,3),(3,1,3),(1,3,3)),
+                    ((3,1,1),(3,1,3),(3,3,3),(1,3,3))
+                    ]
+    avg(x,y) = (x == 1 && y == 3) || (x == 3 && y == 1) ? 2 : x
+    indexavg(x,y) = CartesianIndex(avg.(Tuple(x),Tuple(y)))
+ 
     cell_idx = 0
     @inbounds for k in 1:n_cells_z, j in 1:n_cells_y, i in 1:n_cells_x
         cube = numbering[(2*(i-1) + 1):(2*i + 1), (2*(j-1)+1): 2*j + 1, (2*(k-1) +1): (2*k +1)]
 
-        localnodes = [  ((1,1,1),(3,1,1),(1,3,1),(1,3,3)),
-                        ((1,1,1),(1,1,3),(3,1,1),(1,3,3)),
-                        ((3,1,1),(3,3,1),(1,3,1),(1,3,3)),
-                        ((3,1,1),(3,3,3),(3,3,1),(1,3,3)),
-                        ((3,1,1),(1,1,3),(3,1,3),(1,3,3)),
-                        ((3,1,1),(3,1,3),(3,3,3),(1,3,3))
-                        ]
-        avg(x,y) = (x == 1 && y == 3) || (x == 3 && y == 1) ? 2 : x
-        indexavg(x,y) = CartesianIndex(avg.(Tuple(x),Tuple(y)))
         for (idx, p1vertices) in enumerate(localnodes)
             v1,v2,v3,v4 = map(CartesianIndex,p1vertices)
             cells[cell_idx + idx] = QuadraticTetrahedron((cube[v1],cube[v2],cube[v3],cube[v4],

--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -20,6 +20,7 @@ The following interpolations are implemented:
 * `Lagrange{3,RefTetrahedron,1}`
 * `Lagrange{3,RefTetrahedron,2}`
 
+
 # Examples
 ```jldoctest
 julia> ip = Lagrange{2,RefTetrahedron,2}()
@@ -405,3 +406,37 @@ function value(ip::Serendipity{2,RefCube,2}, i::Int, ξ::Vec{2})
     i == 8 && return 0.5(1 - ξ_x) * (1 - ξ_y * ξ_y)
     throw(ArgumentError("no shape function $i for interpolation $ip"))
 end
+
+######################
+# Piecewise Constant #
+######################
+
+struct PiecewiseConstant{dim,shape,order} <: Interpolation{dim,shape,order} end
+
+getnbasefunctions(::PiecewiseConstant{dim,shape,1}) where {dim,shape} = 1
+ncelldofs(::PiecewiseConstant{dim,shape,1}) where {dim,shape} = 1
+
+getlowerdim(::PiecewiseConstant{dim,shape,1}) where {dim,shape} = PiecewiseConstant{dim-1,shape,1}()
+#TODO: implement this?
+#getlowerorder(::PiecewiseConstant{2,RefCube,2}) = Lagrange{2,RefCube,1}()
+nvertexdofs(::PiecewiseConstant{dim,shape,1}) where {dim,shape} = 0
+nedgedofs(::PiecewiseConstant{dim,shape,1}) where {dim,shape}  = 0
+
+#faces(::Serendipity{2,RefCube,2}) = ((1,2,5), (2,3,6), (3,4,7), (4,1,8))
+
+
+function value(ip::PiecewiseConstant{dim,shape,1}, i::Int, ξ::Vec{dim}) where  {dim,shape}
+    i == 1 && return 1.0
+    throw(ArgumentError("no shape function $i for interpolation $ip"))
+end
+
+function reference_coordinates(::PiecewiseConstant{dim,shape,1}) where {dim,shape}
+    return reference_coordinates(Lagrange{dim,shape,1}())
+end
+
+function faces(::PiecewiseConstant{dim,shape,1}) where {dim,shape}
+    return faces(Lagrange{dim,shape,1}())
+end
+
+
+


### PR DESCRIPTION
Add a function for generating regular P2 triangulations with Quadratic
Tetrahedral elements

I've briefly tested the code and it seems to work. Somebody should go over the code that creates the boundary facesets, as I don't understand it and just copied the relevant sections from generate_grid(Tetrahedron, ....) 