### PR TITLE
Fix CellIterator for mixed meshes

### DIFF
--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -84,10 +84,10 @@ Base.eltype(::Type{T})         where {T<:CellIterator} = T
 
 function reinit!(ci::CellIterator{dim,C}, i::Int) where {dim,C}
     ci.current_cellid[] = ci.cellset[i]
-    
+
     ci.flags.nodes  && cellnodes!(ci.nodes, ci.dh, ci.current_cellid[])
     ci.flags.coords && cellcoords!(ci.coords, ci.dh, ci.current_cellid[])
-    
+
     if isdefined(ci, :dh) && ci.flags.celldofs # update celldofs
         celldofs!(ci.celldofs, ci.dh, ci.current_cellid[])
     end

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -34,7 +34,7 @@ struct CellIterator{dim,C,T}
     celldofs::Vector{Int}
 
     function CellIterator{dim,C,T}(dh::Union{DofHandler{dim,C,T}, MixedDofHandler{dim,C,T}}, cellset::AbstractVector{Int}, flags::UpdateFlags) where {dim,C,T}
-        isconcretetype(C) || _check_same_celltype(grid, cellset)
+        isconcretetype(C) || _check_same_celltype(dh.grid, cellset)
         N = nnodes_per_cell(dh.grid, first(cellset))
         cell = ScalarWrapper(0)
         nodes = zeros(Int, N)

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -39,7 +39,7 @@ struct CellIterator{dim,C,T}
         cell = ScalarWrapper(0)
         nodes = zeros(Int, N)
         coords = zeros(Vec{dim,T}, N)
-        n = ndofs_per_cell(dh)
+        n = ndofs_per_cell(dh, first(cellset))
         celldofs = zeros(Int, n)
         return new{dim,C,T}(flags, dh.grid, cell, nodes, coords, cellset, dh, celldofs)
     end


### PR DESCRIPTION
For a mesh that has cells with different numbers of nodes the 
CellIterator does not work, if it initializes the CellIterator based on 
the number of dofs that the MixedDofHandler returns. n_dofs_per_cell(dh) in that case returns the number of dofs of the first cell in the MixedDofHandler and not the number of dofs of the first cell of the given cellset.

This caused me problems when combining 4-noded cohesive elements with triangular bulk elements, but I think it is a problem with any combination of elements with different number of nodes.