### PR TITLE
add dof_range function for MixedDofHandler

### DIFF
--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -85,7 +85,7 @@ julia> dof_range(dh, :p)
 10:12
 ```
 """
-function dof_range(dh::AbstractDofHandler, field_name::Symbol)
+function dof_range(dh::DofHandler, field_name::Symbol)
     f = find_field(dh, field_name)
     offset = field_offset(dh, field_name)
     n_field_dofs = getnbasefunctions(dh.field_interpolations[f])::Int * dh.field_dims[f]

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -385,6 +385,15 @@ function field_offset(fh::FieldHandler, field_name::Symbol)
     return offset
 end
 
+function JuAFEM.dof_range(fh::FieldHandler, field_name::Symbol)
+    f = JuAFEM.find_field(fh, field_name)
+    offset = JuAFEM.field_offset(fh, field_name)
+    field_interpolation = fh.fields[f].interpolation
+    field_dim = fh.fields[f].dim
+    n_field_dofs = getnbasefunctions(field_interpolation) * field_dim
+    return (offset+1):(offset+n_field_dofs)
+end
+
 find_field(dh::MixedDofHandler, field_name::Symbol) = find_field(first(dh.fieldhandlers), field_name)
 field_offset(dh::MixedDofHandler, field_name::Symbol) = field_offset(first(dh.fieldhandlers), field_name)
 getfieldinterpolation(dh::MixedDofHandler, field_idx::Int) = dh.fieldhandlers[1].fields[field_idx].interpolation

--- a/test/test_dofs.jl
+++ b/test/test_dofs.jl
@@ -19,5 +19,12 @@ JuAFEM.renumber!(JuAFEM.renumber!(dh, perm), iperm)
 # dof_range
 @test (@inferred dof_range(dh, :u)) == 1:12
 @test (@inferred dof_range(dh, :p)) == 13:15
+# dof_range for FieldHandler (use with MixedDofHandler)
+ip = Lagrange{2, RefTetrahedron, 1}()
+field_u = Field(:u, ip, 2)
+field_c = Field(:c, ip, 1)
+fh = FieldHandler([field_u, field_c], Set(1:getncells(grid)))
+@test dof_range(fh, :u) == 1:6
+@test dof_range(fh, :c) == 7:9
 
 end # testset


### PR DESCRIPTION
The dof_range(dh::AbstractDofHandler) does not work for the MixedDofHandler. It seems specialized on the (initial) DofHandler, so I suggest restricting it to this one.
This PR adds a dof_range function that operates on the FieldHandler. A dof_range(MixedDofHandler) does not make sense, as different FieldHandlers can operate on different cellsets (not every cell 
necessarily has the same dof_range).