### PR TITLE
AbstractPlotting plot functionalities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "30d91d44-8115-11e8-1d28-c19a5ac16de8"
 version = "0.2.0"
 
 [deps]
+AbstractPlotting = "537997a7-5e4e-5d89-9595-2241ea00577e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/src/JuAFEM.jl
+++ b/src/JuAFEM.jl
@@ -5,6 +5,7 @@ using Reexport
 
 using LinearAlgebra
 using SparseArrays
+import AbstractPlotting
 
 using Base: @propagate_inbounds
 
@@ -61,6 +62,9 @@ include("L2_projection.jl")
 
 # Export
 include("Export/VTK.jl")
+
+# Plot
+include("visualization.jl")
 
 # Other
 include("deprecations.jl")

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,0 +1,69 @@
+function dof_to_node(dh::DofHandler, u::Array{T,1}) where T
+    solution = zeros(getnnodes(dh.grid))
+    for cell in CellIterator(dh)
+        _celldofs = celldofs(cell)
+        counter = 1
+        for node in getnodes(cell)
+            solution[node] = u[_celldofs[counter]]
+            counter += 1
+        end
+    end
+    return solution
+end
+
+to_triangle(::Union{Type{Triangle}, Type{QuadraticTriangle}}, elements) = elements[:,1:3]
+to_triangle(::Union{Type{Tetrahedron},Type{QuadraticTetrahedron}}, elements) = vcat(elements[:,[1,2,3]], elements[:,[1,2,4]], elements[:,[2,3,4]], elements[:,[1,4,3]])
+to_triangle(::Union{Type{Quadrilateral}, Type{QuadraticQuadrilateral}}, elements) = vcat(elements[:,[1,2,3]], elements[:,[3,4,1]])
+to_triangle(::Union{Type{Hexahedron}, Type{QuadraticHexahedron}}, elements) = vcat(elements[:,[1,2,3]], elements[:,[3,4,1]], elements[:,[1,5,6]], elements[:,[6,2,1]], elements[:,[2,6,7]], elements[:,[7,3,2]], elements[:,[3,7,8]], elements[:,[8,4,3]], elements[:,[1,4,8]], elements[:,[8,5,1]], elements[:,[5,8,7]], elements[:,[7,6,5]])
+
+AbstractPlotting.plottype(::DofHandler{1, C, T}, ::Array{T, 1}) where {C,T} = AbstractPlotting.lines
+AbstractPlotting.plottype(::DofHandler{dim, C, T}, ::Array{T, 1}) where {dim, C, T} = AbstractPlotting.mesh
+
+function AbstractPlotting.plottype(grid::G) where G<:AbstractGrid
+    if getdim(grid) == 1
+        AbstractPlotting.scatterlines
+    else
+        AbstractPlotting.poly
+    end
+end
+
+function AbstractPlotting.convert_arguments(::AbstractPlotting.PointBased, dh::DofHandler{1, C, T}, u::Array{T, 1}) where {C,T}
+    nodes = getnodes(dh.grid)
+    coords = [node.x[1] for node in nodes]
+    solution = dof_to_node(dh, u) 
+    return ([AbstractPlotting.Point2f0(coords[i], solution[i]) for i in 1:getnnodes(dh.grid)],)
+end
+
+function AbstractPlotting.convert_arguments(::AbstractPlotting.PointBased, grid::Grid{1,C,T}) where {C,T}
+    nodes = getnodes(grid)
+    coords = [node.x[1] for node in nodes]
+    return ([AbstractPlotting.Point2f0(coords[i], 0.0) for i in 1:getnnodes(grid)],)
+end
+
+function AbstractPlotting.mesh(dh::DofHandler, u::Array{T,1}, args...; scale_plot=false, shading=false, kwargs...) where T
+    C = getcelltype(dh.grid)
+    nodes = getnodes(dh.grid)
+    cells = getcells(dh.grid)
+    coords = [node.x[i] for node in nodes, i in 1:getdim(dh.grid)]
+    connectivity = getproperty.(cells, :nodes)
+    N = length(vertices(cells[1]))
+    elements = [element[i] for element in connectivity, i in 1:N]
+    solution = dof_to_node(dh, u)
+    triangle_elements = to_triangle(C, elements) 
+    return AbstractPlotting.mesh(coords, triangle_elements, color=solution, args...; scale_plot=scale_plot, shading=shading, kwargs...)
+end
+
+function AbstractPlotting.surface(dh::DofHandler, u::Array{T,1}, args...; scale_plot=false, shading=false, kwargs...) where T
+    @assert getdim(dh.grid) == 2 "Only 2D solutions supported!"
+    C = getcelltype(dh.grid)
+    nodes = getnodes(dh.grid)
+    cells = getcells(dh.grid)
+    coords = [node.x[i] for node in nodes, i in 1:2]
+    connectivity = getproperty.(cells, :nodes)
+    N = length(vertices(cells[1]))
+    elements = [element[i] for element in connectivity, i in 1:N]
+    solution = dof_to_node(dh, u)
+    points = [AbstractPlotting.Point3f0(coord[1], coord[2], solution[idx]) for (idx,coord) in enumerate(eachrow(coords))]
+    triangle_elements = to_triangle(C, elements)  
+    return AbstractPlotting.mesh(points, triangle_elements, color=solution, args...; scale_plot=scale_plot, shading=shading, kwargs...)
+end


### PR DESCRIPTION
## What's new
- `AbstractPlotting` dep, in order to pollute the namespace
- Any PointBased plot, i.e. scatter, scatterlines, lines, barplot and so on can be called on `dh,u`, as well as a default `plot(dh, u)` in 1D
- in 2D you can either call `mesh(dh, u)` or `surface(dh,u)`
- in 3D you can call `mesh(dh, u)`

## Feedback
I'd be happy if you try it out. Just checkout the makie branch, include the heat example and play with dimensionality and celltype of the problem. After the include, call a chosen Makie backend, e.g. `using GLMakie, AbstractPlotting`. Call any previously mentioned function on `dh` and `u`. Also, it would be nice if someone could give feedback on non-regular grids that are imported from somewhere else.

![mesh3d](https://user-images.githubusercontent.com/27497290/102252008-d53f1680-3f05-11eb-88de-17db871e8505.gif)
![surfaceplot](https://user-images.githubusercontent.com/27497290/102252019-d7a17080-3f05-11eb-93d0-b0f1bde6c39a.gif)
