### PR TITLE
Mesh Interface Rework

### DIFF
--- a/src/Dofs/ConstraintHandler.jl
+++ b/src/Dofs/ConstraintHandler.jl
@@ -85,7 +85,7 @@ end
 
 Applies the boundary condition to the right-hand-side vector without modifying the stiffness matrix
 """
-function apply_rhs!(data::RHSData, f::AbstractVector, ch::ConstraintHandler, applyzero::Bool=false)	
+function apply_rhs!(data::RHSData, f::AbstractVector, ch::ConstraintHandler, applyzero::Bool=false)
     K = data.constrained_columns
     @assert length(f) == 0 || length(f) == size(K, 1)
     @boundscheck length(f) == 0 || checkbounds(f, ch.prescribed_dofs)
@@ -339,7 +339,7 @@ function WriteVTK.vtk_point_data(vtkfile, ch::ConstraintHandler)
             dbc.field_name != field && continue
             if eltype(dbc.faces) <: Tuple
                 for (cellidx, faceidx) in dbc.faces
-                    for facenode in faces(ch.dh.grid.cells[cellidx])[faceidx]
+                    for facenode in faces(ch.dh.grid, ch.dh.grid.cells[cellidx])[faceidx]
                         for component in dbc.components
                             data[component, facenode] = 1
                         end
@@ -451,7 +451,7 @@ function add!(ch::ConstraintHandler, fh::FieldHandler, dbc::Dirichlet)
     interpolation = getfieldinterpolations(fh)[field_idx]
     field_dim = getfielddims(fh)[field_idx]
     bcvalue = fh.bc_values[field_idx]
-    
+
     JuAFEM._add!(ch, dbc, dbc.faces, interpolation, field_dim, field_offset(fh, dbc.field_name), bcvalue)
     return ch
 end

--- a/src/Dofs/DofHandler.jl
+++ b/src/Dofs/DofHandler.jl
@@ -168,7 +168,7 @@ function __close!(dh::DofHandler{dim}) where {dim}
             interpolation_info = interpolation_infos[fi]
             @debug println("  field: $(dh.field_names[fi])")
             if interpolation_info.nvertexdofs > 0
-                for vertex in vertices(cell)
+                for vertex in vertices(dh.grid, cell)
                     @debug println("    vertex#$vertex")
                     token = Base.ht_keyindex2!(vertexdicts[fi], vertex)
                     if token > 0 # haskey(vertexdicts[fi], vertex) # reuse dofs
@@ -191,7 +191,7 @@ function __close!(dh::DofHandler{dim}) where {dim}
             end
             if dim == 3 # edges only in 3D
                 if interpolation_info.nedgedofs > 0
-                    for edge in edges(cell)
+                    for edge in edges(dh.grid, cell)
                         sedge, dir = sortedge(edge)
                         @debug println("    edge#$sedge dir: $(dir)")
                         token = Base.ht_keyindex2!(edgedicts[fi], sedge)
@@ -218,7 +218,7 @@ function __close!(dh::DofHandler{dim}) where {dim}
                 end
             end
             if interpolation_info.nfacedofs > 0 && (interpolation_info.dim == dim)
-                for face in faces(cell)
+                for face in faces(dh.grid, cell)
                     sface = sortface(face) # TODO: faces(cell) may as well just return the sorted list
                     @debug println("    face#$sface")
                     token = Base.ht_keyindex2!(facedicts[fi], sface)

--- a/src/Dofs/MixedDofHandler.jl
+++ b/src/Dofs/MixedDofHandler.jl
@@ -248,19 +248,19 @@ function _close!(dh::MixedDofHandler{dim}, cellnumbers, field_names, field_dims,
             ip_info = ip_infos[fi]
 
             if ip_info.nvertexdofs > 0
-                nextdof = add_vertex_dofs(cell_dofs, cell, vertexdicts[fi], field_dims[fi], ip_info.nvertexdofs, nextdof)
+                nextdof = add_vertex_dofs(dh.grid, cell_dofs, cell, vertexdicts[fi], field_dims[fi], ip_info.nvertexdofs, nextdof)
             end
 
             if ip_info.nedgedofs > 0 && dim == 3 #Edges only in 3d
-                nextdof = add_edge_dofs(cell_dofs, cell, edgedicts[fi], field_dims[fi], ip_info.nedgedofs, nextdof)
+                nextdof = add_edge_dofs(dh.grid, cell_dofs, cell, edgedicts[fi], field_dims[fi], ip_info.nedgedofs, nextdof)
             end
 
             if ip_info.nfacedofs > 0 && (ip_info.dim == dim)
-                nextdof = add_face_dofs(cell_dofs, cell, facedicts[fi], field_dims[fi], ip_info.nfacedofs, nextdof)
+                nextdof = add_face_dofs(dh.grid, cell_dofs, cell, facedicts[fi], field_dims[fi], ip_info.nfacedofs, nextdof)
             end
 
             if ip_info.ncelldofs > 0
-                nextdof = add_cell_dofs(cell_dofs, ci, celldicts[fi], field_dims[fi], ip_info.ncelldofs, nextdof)
+                nextdof = add_cell_dofs(dh.grid, cell_dofs, ci, celldicts[fi], field_dims[fi], ip_info.ncelldofs, nextdof)
             end
 
         end
@@ -294,8 +294,8 @@ function get_or_create_dofs!(nextdof, field_dim; dict, key)
     end
 end
 
-function add_vertex_dofs(cell_dofs, cell, vertexdict, field_dim, nvertexdofs, nextdof)
-    for vertex in JuAFEM.vertices(cell)
+function add_vertex_dofs(grid, cell_dofs, cell, vertexdict, field_dim, nvertexdofs, nextdof)
+    for vertex in JuAFEM.vertices(grid, cell)
         @debug "\tvertex #$vertex"
         nextdof, dofs = get_or_create_dofs!(nextdof, field_dim, dict=vertexdict, key=vertex)
         push!(cell_dofs, dofs...)
@@ -303,10 +303,10 @@ function add_vertex_dofs(cell_dofs, cell, vertexdict, field_dim, nvertexdofs, ne
     return nextdof
 end
 
-function add_face_dofs(cell_dofs, cell, facedict, field_dim, nfacedofs, nextdof)
+function add_face_dofs(grid, cell_dofs, cell, facedict, field_dim, nfacedofs, nextdof)
     @assert nfacedofs == 1 "Currently only supports interpolations with nfacedofs = 1"
 
-    for face in JuAFEM.faces(cell)
+    for face in JuAFEM.faces(grid, cell)
         sface = JuAFEM.sortface(face)
         @debug "\tface #$sface"
         nextdof, dofs = get_or_create_dofs!(nextdof, field_dim, dict=facedict, key=sface)
@@ -315,9 +315,9 @@ function add_face_dofs(cell_dofs, cell, facedict, field_dim, nfacedofs, nextdof)
     return nextdof
 end
 
-function add_edge_dofs(cell_dofs, cell, edgedict, field_dim, nedgedofs, nextdof)
+function add_edge_dofs(grid, cell_dofs, cell, edgedict, field_dim, nedgedofs, nextdof)
     @assert nedgedofs == 1 "Currently only supports interpolations with nedgedofs = 1"
-    for edge in JuAFEM.edges(cell)
+    for edge in JuAFEM.edges(grid, cell)
         sedge, dir = JuAFEM.sortedge(edge)
         @debug "\tedge #$sedge"
         nextdof, dofs = get_or_create_dofs!(nextdof, field_dim, dict=edgedict, key=sedge)
@@ -326,7 +326,7 @@ function add_edge_dofs(cell_dofs, cell, edgedict, field_dim, nedgedofs, nextdof)
     return nextdof
 end
 
-function add_cell_dofs(cell_dofs, cell, celldict, field_dim, ncelldofs, nextdof)
+function add_cell_dofs(grid, cell_dofs, cell, celldict, field_dim, ncelldofs, nextdof)
     for celldof in 1:ncelldofs
         @debug "\tcell #$cell"
         nextdof, dofs = get_or_create_dofs!(nextdof, field_dim, dict=celldict, key=cell)

--- a/src/Grid/grid.jl
+++ b/src/Grid/grid.jl
@@ -177,7 +177,7 @@ function addfaceset!(grid::AbstractGrid, name::String, f::Function; all::Bool=tr
     _check_setname(grid.facesets, name)
     faceset = Set{Tuple{Int,Int}}()
     for (cell_idx, cell) in enumerate(getcells(grid))
-        for (face_idx, face) in enumerate(faces(cell))
+        for (face_idx, face) in enumerate(faces(grid, cell))
             pass = all
             for node_idx in face
                 v = f(grid.nodes[node_idx].x)
@@ -270,24 +270,24 @@ const celltypes = Dict{DataType, String}(Cell{1,2,2}  => "Line",
 # dofs over a mesh. For this we can ignore the nodes on edged, faces and inside cells,
 # we only need to use the nodes that are vertices.
 # 1D: vertices
-faces(c::Union{Line,QuadraticLine}) = (c.nodes[1], c.nodes[2])
-vertices(c::Union{Line,Line2D,Line3D,QuadraticLine}) = (c.nodes[1], c.nodes[2])
+faces(grid::AbstractGrid, c::Union{Line,QuadraticLine}) = (c.nodes[1], c.nodes[2])
+vertices(grid::AbstractGrid, c::Union{Line,Line2D,Line3D,QuadraticLine}) = (c.nodes[1], c.nodes[2])
 # 2D: vertices, faces
-faces(c::Line2D) = ((c.nodes[1],c.nodes[2]),)
-vertices(c::Union{Triangle,QuadraticTriangle}) = (c.nodes[1], c.nodes[2], c.nodes[3])
-faces(c::Union{Triangle,QuadraticTriangle}) = ((c.nodes[1],c.nodes[2]), (c.nodes[2],c.nodes[3]), (c.nodes[3],c.nodes[1]))
-vertices(c::Union{Quadrilateral,Quadrilateral3D,QuadraticQuadrilateral}) = (c.nodes[1], c.nodes[2], c.nodes[3], c.nodes[4])
-faces(c::Union{Quadrilateral,QuadraticQuadrilateral}) = ((c.nodes[1],c.nodes[2]), (c.nodes[2],c.nodes[3]), (c.nodes[3],c.nodes[4]), (c.nodes[4],c.nodes[1]))
+faces(grid::AbstractGrid, c::Line2D) = ((c.nodes[1],c.nodes[2]),)
+vertices(grid::AbstractGrid, c::Union{Triangle,QuadraticTriangle}) = (c.nodes[1], c.nodes[2], c.nodes[3])
+faces(grid::AbstractGrid, c::Union{Triangle,QuadraticTriangle}) = ((c.nodes[1],c.nodes[2]), (c.nodes[2],c.nodes[3]), (c.nodes[3],c.nodes[1]))
+vertices(grid::AbstractGrid, c::Union{Quadrilateral,Quadrilateral3D,QuadraticQuadrilateral}) = (c.nodes[1], c.nodes[2], c.nodes[3], c.nodes[4])
+faces(grid::AbstractGrid, c::Union{Quadrilateral,QuadraticQuadrilateral}) = ((c.nodes[1],c.nodes[2]), (c.nodes[2],c.nodes[3]), (c.nodes[3],c.nodes[4]), (c.nodes[4],c.nodes[1]))
 # 3D: vertices, edges, faces
-edges(c::Line3D) = ((c.nodes[1],c.nodes[2]),)
-vertices(c::Union{Tetrahedron,QuadraticTetrahedron}) = (c.nodes[1], c.nodes[2], c.nodes[3], c.nodes[4])
-edges(c::Union{Tetrahedron,QuadraticTetrahedron}) = ((c.nodes[1],c.nodes[2]), (c.nodes[2],c.nodes[3]), (c.nodes[3],c.nodes[1]), (c.nodes[1],c.nodes[4]), (c.nodes[2],c.nodes[4]), (c.nodes[3],c.nodes[4]))
-faces(c::Union{Tetrahedron,QuadraticTetrahedron}) = ((c.nodes[1],c.nodes[2],c.nodes[3]), (c.nodes[1],c.nodes[2],c.nodes[4]), (c.nodes[2],c.nodes[3],c.nodes[4]), (c.nodes[1],c.nodes[4],c.nodes[3]))
-vertices(c::Union{Hexahedron,QuadraticHexahedron}) = (c.nodes[1], c.nodes[2], c.nodes[3], c.nodes[4], c.nodes[5], c.nodes[6], c.nodes[7], c.nodes[8])
-edges(c::Union{Hexahedron,QuadraticHexahedron}) = ((c.nodes[1],c.nodes[2]), (c.nodes[2],c.nodes[3]), (c.nodes[3],c.nodes[4]), (c.nodes[4],c.nodes[1]), (c.nodes[1],c.nodes[5]), (c.nodes[2],c.nodes[6]), (c.nodes[3],c.nodes[7]), (c.nodes[4],c.nodes[8]), (c.nodes[5],c.nodes[6]), (c.nodes[6],c.nodes[7]), (c.nodes[7],c.nodes[8]), (c.nodes[8],c.nodes[5]))
-faces(c::Union{Hexahedron,QuadraticHexahedron}) = ((c.nodes[1],c.nodes[4],c.nodes[3],c.nodes[2]), (c.nodes[1],c.nodes[2],c.nodes[6],c.nodes[5]), (c.nodes[2],c.nodes[3],c.nodes[7],c.nodes[6]), (c.nodes[3],c.nodes[4],c.nodes[8],c.nodes[7]), (c.nodes[1],c.nodes[5],c.nodes[8],c.nodes[4]), (c.nodes[5],c.nodes[6],c.nodes[7],c.nodes[8]))
-edges(c::Union{Quadrilateral3D}) = ((c.nodes[1],c.nodes[2]), (c.nodes[2],c.nodes[3]), (c.nodes[3],c.nodes[4]), (c.nodes[4],c.nodes[1]))
-faces(c::Union{Quadrilateral3D}) = ((c.nodes[1],c.nodes[2],c.nodes[3],c.nodes[4]),)
+edges(grid::AbstractGrid, c::Line3D) = ((c.nodes[1],c.nodes[2]),)
+vertices(grid::AbstractGrid, c::Union{Tetrahedron,QuadraticTetrahedron}) = (c.nodes[1], c.nodes[2], c.nodes[3], c.nodes[4])
+edges(grid::AbstractGrid, c::Union{Tetrahedron,QuadraticTetrahedron}) = ((c.nodes[1],c.nodes[2]), (c.nodes[2],c.nodes[3]), (c.nodes[3],c.nodes[1]), (c.nodes[1],c.nodes[4]), (c.nodes[2],c.nodes[4]), (c.nodes[3],c.nodes[4]))
+faces(grid::AbstractGrid, c::Union{Tetrahedron,QuadraticTetrahedron}) = ((c.nodes[1],c.nodes[2],c.nodes[3]), (c.nodes[1],c.nodes[2],c.nodes[4]), (c.nodes[2],c.nodes[3],c.nodes[4]), (c.nodes[1],c.nodes[4],c.nodes[3]))
+vertices(grid::AbstractGrid, c::Union{Hexahedron,QuadraticHexahedron}) = (c.nodes[1], c.nodes[2], c.nodes[3], c.nodes[4], c.nodes[5], c.nodes[6], c.nodes[7], c.nodes[8])
+edges(grid::AbstractGrid, c::Union{Hexahedron,QuadraticHexahedron}) = ((c.nodes[1],c.nodes[2]), (c.nodes[2],c.nodes[3]), (c.nodes[3],c.nodes[4]), (c.nodes[4],c.nodes[1]), (c.nodes[1],c.nodes[5]), (c.nodes[2],c.nodes[6]), (c.nodes[3],c.nodes[7]), (c.nodes[4],c.nodes[8]), (c.nodes[5],c.nodes[6]), (c.nodes[6],c.nodes[7]), (c.nodes[7],c.nodes[8]), (c.nodes[8],c.nodes[5]))
+faces(grid::AbstractGrid, c::Union{Hexahedron,QuadraticHexahedron}) = ((c.nodes[1],c.nodes[4],c.nodes[3],c.nodes[2]), (c.nodes[1],c.nodes[2],c.nodes[6],c.nodes[5]), (c.nodes[2],c.nodes[3],c.nodes[7],c.nodes[6]), (c.nodes[3],c.nodes[4],c.nodes[8],c.nodes[7]), (c.nodes[1],c.nodes[5],c.nodes[8],c.nodes[4]), (c.nodes[5],c.nodes[6],c.nodes[7],c.nodes[8]))
+edges(grid::AbstractGrid, c::Union{Quadrilateral3D}) = ((c.nodes[1],c.nodes[2]), (c.nodes[2],c.nodes[3]), (c.nodes[3],c.nodes[4]), (c.nodes[4],c.nodes[1]))
+faces(grid::AbstractGrid, c::Union{Quadrilateral3D}) = ((c.nodes[1],c.nodes[2],c.nodes[3],c.nodes[4]),)
 
 # random stuff
 default_interpolation(::Union{Type{Line},Type{Line2D},Type{Line3D}}) = Lagrange{1,RefCube,1}()


### PR DESCRIPTION
Hi folks, this PR contains some sketches on how we could extend the interface to the finite element mesh (grid). The basic idea is to simply the integration of different kinds of meshes by extending the interface to the mesh. The changes here should not affect any user code directly.

TODO
* [ ] Extend faces, edges, vertices 
* [ ] What about nodes?
* [ ] Investigate interface to cells
* [ ] Example why when this is useful
* [ ] Update Docs